### PR TITLE
[INTERNAL] update readme, use package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Please see [command-line interface](./docs/guide/cli.md) for more details.
 
 
 ### Available migration tasks
-A list of the current migration tasks can be found [here](./docs/guide/tasks.md)
+A list of currently available migration tasks can be found [here](./docs/guide/tasks.md)
 
-### Printing options for migration output
-A list of the printing options can be found [here](./docs/guide/print.md)
+### Formatting options
+A list of options to configure the formatting of migration output can be found [here](./docs/guide/print.md)
 
 ## Contributing
-Please check our [Contribution Guidelines](https://github.com/SAP/ui5-migration/blob/master/CONTRIBUTING.md).
+Please check our [Contribution Guidelines](https://github.com/SAP/ui5-migration/blob/master/CONTRIBUTING.md). Your input and support is welcome!
 
 ## Support
 Please follow our [Contribution Guidelines](https://github.com/SAP/ui5-migration/blob/master/CONTRIBUTING.md#report-an-issue) on how to report an issue.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Next to the standalone CLI command an add'tl API is provided, which simplifies i
 
 ## Installation
 
+### Requirements
+- [Node.js](https://nodejs.org/) (**version 8.5 or higher** ⚠️)
+
 The migration tool is currently available for experimental usage. It can be installed with npm.
 ```cli
 npm install --global @ui5/migration

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ![UI5 logo](./docs/images/UI5_logo_wide.png)
 
 # ui5-migration
-Tooling to support the migration of UI5 projects by adapting your code for new UI5 framework versions.
+> Tooling to support the migration of UI5 projects by adapting your code for new UI5 framework versions.
+
+_**Note:** This project is currently in beta and in the process to become available via npm. While there are ongoing improvements and round-offs being applied to this project, we see the upcoming release as a great opportunity to collect feedback from the community to further advance the UI5 migration tooling. Appreciated._
 
 The UI5 migration tool performs source code replacements and optimizations to improve a UI5 project's codebase.
 The source code modification aims to reduce deprecated API and to leverage best practices.
@@ -44,12 +46,8 @@ Please see [command-line interface](./docs/guide/cli.md) for more details.
 ### Available migration tasks
 A list of the current migration tasks can be found [here](./docs/guide/tasks.md)
 
-### Available migration output printing options
+### Printing options for migration output
 A list of the printing options can be found [here](./docs/guide/print.md)
-
-## FAQ
-### How can I contribute?
-Please check our [Contribution Guidelines](https://github.com/SAP/ui5-migration/blob/master/CONTRIBUTING.md).
 
 ## Contributing
 Please check our [Contribution Guidelines](https://github.com/SAP/ui5-migration/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -10,25 +10,26 @@ Migration consists of an analysis part and a code modification part.
 
 Next to the standalone CLI command an add'tl API is provided, which simplifies integration into other tools (e.g. into custom node.js scripts, grunt).
 
-IMNPORTANT: The modified source code needs to be manually reviewed and tested. There is no 100% guarantee that the modified code works as expected.
+**IMNPORTANT**: The modified source code needs to be manually reviewed and tested. There is no 100% guarantee that the modified code works as expected.
 
 **If you want to migrate your codebase, please see the [migration guide](./docs/guide/migrationguide.md)**
 
 
 ## Installation
 
-Run the following command to delete the previous installation to avoid conflicts
-```cli
-npm uninstall ui5-migration --global
-```
-
 The migration tool is currently available for experimental usage. It can be installed with npm.
 ```cli
-npm install ui5-migration --global
+npm install --global @ui5/migration
 ```
 
 ## Usage
 ### CLI
+
+To verify that the installation worked run:
+```cli
+ui5-migration --help
+```
+
 Execute migration for the current folder:
 ```cli
 ui5-migration migrate

--- a/README.md
+++ b/README.md
@@ -38,19 +38,7 @@ Execute migration for the current folder:
 ui5-migration migrate
 ```
 
-Currently the CLI is the easiest way to use the ui5-migration tool. Please see [command-line interface](./docs/guide/cli.md) for more details.
-
-### API
-The ui5-migration API might be consumed as in the following:
-
-```js
-var ui5Migration = require('ui5-migration');
-var mySourceCode = "mysourceCodeString";
-var aTasks = undefined;
-var migrationResult = await ui5Migration.migrateString(aTasks, mySourceCode);
-var log = migrationResult.log;
-var myModifiedSourceCode = migrationResult.output;
-```
+Please see [command-line interface](./docs/guide/cli.md) for more details.
 
 
 ### Available migration tasks

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Migration consists of an analysis part and a code modification part.
 
 Next to the standalone CLI command an add'tl API is provided, which simplifies integration into other tools (e.g. into custom node.js scripts, grunt).
 
-**IMNPORTANT**: The modified source code needs to be manually reviewed and tested. There is no 100% guarantee that the modified code works as expected.
+**IMPORTANT**: The modified source code needs to be manually reviewed and tested. There is no 100% guarantee that the modified code works as expected.
 
 **If you want to migrate your codebase, please see the [migration guide](./docs/guide/migrationguide.md)**
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ui5/migration",
   "version": "0.1.0",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.5"
   },
   "keywords": [
     "openui5",


### PR DESCRIPTION
Use package name for installation.
Remove uninstall section because it was mostly relevant when project
was manually linked.
Emphasize important statement