### PR TITLE
[INTERNAL] Streamline whitespace tests with eol characters

### DIFF
--- a/test/util/whitespace/AstStringOptimizeStrategyTest.ts
+++ b/test/util/whitespace/AstStringOptimizeStrategyTest.ts
@@ -6,6 +6,8 @@ const assert = require("assert");
 const fs = require("fs");
 const rootDir = "./test/util/whitespace/astresources/";
 
+const EOL_REGEXP = /\r?\n/g;
+
 describe("AstStringOptimizeStrategy", function() {
 	it("Should optimize batch", async function() {
 		const source = fs.readFileSync(rootDir + "batch.source.js", "UTF-8");
@@ -53,9 +55,15 @@ describe("AstStringOptimizeStrategy", function() {
 	});
 
 	it("Should optimize abap", async function() {
-		const source = fs.readFileSync(rootDir + "abap.source.js", "UTF-8");
-		const modified = fs.readFileSync(rootDir + "abap.modified.js", "UTF-8");
-		const expected = fs.readFileSync(rootDir + "abap.expected.js", "UTF-8");
+		let source = fs.readFileSync(rootDir + "abap.source.js", "UTF-8");
+		let modified = fs.readFileSync(rootDir + "abap.modified.js", "UTF-8");
+		let expected = fs.readFileSync(rootDir + "abap.expected.js", "UTF-8");
+
+
+		source = source.replace(EOL_REGEXP, "\r\n");
+		modified = modified.replace(EOL_REGEXP, "\r\n");
+		expected = expected.replace(EOL_REGEXP, "\r\n");
+
 		const reports = [];
 		const astStringOptimizeStrategy =
 			new AstStringOptimizeStrategy(new CustomReporter(reports, "trace"));
@@ -83,11 +91,15 @@ describe("AstStringOptimizeStrategy", function() {
 	});
 
 	it("Should optimize custom", async function() {
-		const source = fs.readFileSync(rootDir + "custom.source.js", "UTF-8");
-		const modified =
-			fs.readFileSync(rootDir + "custom.modified.js", "UTF-8");
-		const expected =
-			fs.readFileSync(rootDir + "custom.expected.js", "UTF-8");
+		let source = fs.readFileSync(rootDir + "custom.source.js", "UTF-8");
+		let modified = fs.readFileSync(rootDir + "custom.modified.js", "UTF-8");
+		let expected = fs.readFileSync(rootDir + "custom.expected.js", "UTF-8");
+
+		source = source.replace(EOL_REGEXP, "\r\n");
+		modified = modified.replace(EOL_REGEXP, "\r\n");
+		expected = expected.replace(EOL_REGEXP, "\r\n");
+
+
 		const reports = [];
 		const astStringOptimizeStrategy =
 			new AstStringOptimizeStrategy(new CustomReporter(reports, "trace"));

--- a/test/util/whitespace/DiffAndAstStringOptimizeStrategyTest.ts
+++ b/test/util/whitespace/DiffAndAstStringOptimizeStrategyTest.ts
@@ -6,6 +6,8 @@ const assert = require("assert");
 const fs = require("fs");
 const rootDir = "./test/util/whitespace/diffandastresources/";
 
+const EOL_REGEXP = /\r?\n/g;
+
 describe("DiffAndAstStringOptimizeStrategy", function() {
 	const aCommonLogs = [
 		"trace: DIFF: Found 123 diffs",
@@ -51,12 +53,15 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	];
 
 	const commonLogs = (begin, end) => {
-		return [`trace: Performing DiffStringOptimizeStrategy ${begin} and ${end}`].concat(aCommonLogs);
+		return [
+			`trace: Performing DiffStringOptimizeStrategy ${begin} and ${end}`
+		].concat(aCommonLogs);
 	};
 
 
 	[{
 		baseName : "batch",
+		fileEOL : "\r\n",
 		logs : [
 			...commonLogs(76171, 76259),
 			"trace: DIFF Skipped 653:  '[\\r][\\n][\\t]'",
@@ -113,6 +118,7 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	},
 	 {
 		 baseName : "list",
+		 fileEOL : "\r\n",
 		 logs : [
 			 ...commonLogs(1363, 1476),
 			 "trace: DIFF Skipped 653:  '[\\r][\\n][ ][ ][ ][ ]'",
@@ -169,6 +175,7 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "actions",
+		 fileEOL : "\r\n",
 		 logs : [
 			 "trace: Performing DiffStringOptimizeStrategy 496 and 576",
 			 "trace: DIFF: Found 33 diffs",
@@ -178,6 +185,7 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "abap",
+		 fileEOL : "\r\n",
 		 logs : [
 			 "trace: Performing DiffStringOptimizeStrategy 408 and 428",
 			 "trace: DIFF: Found 14 diffs",
@@ -204,6 +212,7 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "endless",
+		 fileEOL : "\r\n",
 		 logs : [
 			 "trace: Performing DiffStringOptimizeStrategy 189 and 93",
 			 "trace: DIFF: Found 21 diffs", "trace: DIFF Added 48:  '[ ]'",
@@ -215,6 +224,7 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "structure",
+		 fileEOL : "\r\n",
 		 description :
 			 "structural change by wrapping everything inside a sap.ui.define",
 		 logs : [
@@ -226,6 +236,7 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "structure2",
+		 fileEOL : "\r\n",
 		 description :
 			 "structural change by wrapping everything inside a sap.ui.define",
 		 logs : [
@@ -240,6 +251,7 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "newlines",
+		 fileEOL : "\r\n",
 		 description : "new lines",
 		 logs : [
 			 "trace: Performing DiffStringOptimizeStrategy 2226 and 2407",
@@ -264,6 +276,7 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "multiline",
+		 fileEOL : "\r\n",
 		 description : "multiple lines",
 		 logs : [
 			 "trace: Performing DiffStringOptimizeStrategy 13025 and 13082",
@@ -295,6 +308,7 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "multilineprop",
+		 fileEOL : "\r\n",
 		 description : "multiple lines in property",
 		 logs : [
 			 "trace: Performing DiffStringOptimizeStrategy 10125 and 10441",
@@ -405,12 +419,19 @@ describe("DiffAndAstStringOptimizeStrategy", function() {
 			   (oTestConfig.description ? " (" + oTestConfig.description + ")" :
 										  ""),
 		   async function() {
-			   const source = fs.readFileSync(
+			   let source = fs.readFileSync(
 				   rootDir + oTestConfig.baseName + ".source.js", "UTF-8");
-			   const modified = fs.readFileSync(
+			   let modified = fs.readFileSync(
 				   rootDir + oTestConfig.baseName + ".modified.js", "UTF-8");
-			   const expected = fs.readFileSync(
+			   let expected = fs.readFileSync(
 				   rootDir + oTestConfig.baseName + ".expected.js", "UTF-8");
+
+			   if (oTestConfig.fileEOL) {
+				   source = source.replace(EOL_REGEXP, oTestConfig.fileEOL);
+				   modified = modified.replace(EOL_REGEXP, oTestConfig.fileEOL);
+				   expected = expected.replace(EOL_REGEXP, oTestConfig.fileEOL);
+			   }
+
 			   const reports = [];
 			   const diffAndAstStringOptimizeStrategy =
 				   new DiffAndAstStringOptimizeStrategy(

--- a/test/util/whitespace/DiffStringOptimizeStrategyTest.ts
+++ b/test/util/whitespace/DiffStringOptimizeStrategyTest.ts
@@ -6,6 +6,8 @@ const assert = require("assert");
 const fs = require("fs");
 const rootDir = "./test/util/whitespace/diffresources/";
 
+const EOL_REGEXP = /\r?\n/g;
+
 describe("DiffStringOptimizeStrategy", function() {
 	const aCommonLogs = [
 		"trace: DIFF: Found 123 diffs",
@@ -51,13 +53,16 @@ describe("DiffStringOptimizeStrategy", function() {
 	];
 
 	const commonLogs = (begin, end) => {
-		return [`trace: Performing DiffStringOptimizeStrategy ${begin} and ${end}`].concat(aCommonLogs);
+		return [
+			`trace: Performing DiffStringOptimizeStrategy ${begin} and ${end}`
+		].concat(aCommonLogs);
 	};
 
 
 
 	[{
 		baseName : "batch",
+		fileEOL : "\r\n",
 		logs : [
 			...commonLogs(76171, 76259),
 			"trace: DIFF Skipped 653:  '[\\r][\\n][\\t]'",
@@ -101,6 +106,7 @@ describe("DiffStringOptimizeStrategy", function() {
 	},
 	 {
 		 baseName : "list",
+		 fileEOL : "\r\n",
 		 logs : [
 			 ...commonLogs(1363, 1476),
 			 "trace: DIFF Skipped 653:  '[\\r][\\n][ ][ ][ ][ ]'",
@@ -144,6 +150,7 @@ describe("DiffStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "actions",
+		 fileEOL : "\r\n",
 		 logs : [
 			 "trace: Performing DiffStringOptimizeStrategy 496 and 576",
 			 "trace: DIFF: Found 33 diffs",
@@ -152,6 +159,7 @@ describe("DiffStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "abap",
+		 fileEOL : "\r\n",
 		 logs : [
 			 "trace: Performing DiffStringOptimizeStrategy 408 and 428",
 			 "trace: DIFF: Found 14 diffs",
@@ -165,6 +173,7 @@ describe("DiffStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "endless",
+		 fileEOL : "\r\n",
 		 logs : [
 			 "trace: Performing DiffStringOptimizeStrategy 179 and 83",
 			 "trace: DIFF: Found 16 diffs", "trace: DIFF Added 48:  '[ ]'",
@@ -173,6 +182,7 @@ describe("DiffStringOptimizeStrategy", function() {
 	 },
 	 {
 		 baseName : "structure",
+		 fileEOL : "\r\n",
 		 description :
 			 "structural change by wrapping everything inside a sap.ui.define",
 		 logs : [
@@ -198,12 +208,19 @@ describe("DiffStringOptimizeStrategy", function() {
 			   (oTestConfig.description ? " (" + oTestConfig.description + ")" :
 										  ""),
 		   async function() {
-			   const source = fs.readFileSync(
+			   let source = fs.readFileSync(
 				   rootDir + oTestConfig.baseName + ".source.js", "UTF-8");
-			   const modified = fs.readFileSync(
+			   let modified = fs.readFileSync(
 				   rootDir + oTestConfig.baseName + ".modified.js", "UTF-8");
-			   const expected = fs.readFileSync(
+			   let expected = fs.readFileSync(
 				   rootDir + oTestConfig.baseName + ".expected.js", "UTF-8");
+
+			   if (oTestConfig.fileEOL) {
+				   source = source.replace(EOL_REGEXP, oTestConfig.fileEOL);
+				   modified = modified.replace(EOL_REGEXP, oTestConfig.fileEOL);
+				   expected = expected.replace(EOL_REGEXP, oTestConfig.fileEOL);
+			   }
+
 			   const reports = [];
 			   const diffStringOptimizeStrategy =
 				   new DiffStringOptimizeStrategy(


### PR DESCRIPTION
Whitespace tests require specific EOL characters in test files.
To be git EOL config independent the correct EOL characters are
replaced during test execution.