### PR TITLE
[INTERNAL] Add .gitattributes for consistent EOL across paltforms

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# see http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+
+[*.{css,html,js,less,txt,json,yml,md}]
+trim_trailing_whitespace = true
+end_of_line = lf
+indent_size = 4
+insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Use .gitattributes to have LF as EOL character in all files
Add editorconfig file