### PR TITLE
[FIX] Replacement for native JS types

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1076,8 +1076,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "got": {
       "version": "6.7.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "dependencies": {
     "diff": "^4.0.1",
     "esprima": "^4.0.1",
+    "globals": "^11.12.0",
     "graceful-fs": "^4.1.15",
     "ignore": "^5.1.1",
     "json5": "^2.1.0",

--- a/src/util/AmdCleanerUtil.ts
+++ b/src/util/AmdCleanerUtil.ts
@@ -1336,48 +1336,32 @@ module.exports = {
 		}
 		return importNames;
 	},
+	/**
+	 *
+	 * @param module, e.g. "a/b/c"
+	 */
 	getLocalReference(module: string) {
 		let candidate;
-		let p = module.lastIndexOf("/");
-		if (p >= 0) {
-			candidate = module.slice(p + 1);
-		} else if (/^jquery\.sap\./.test(module)) {
+		if (/^jquery\.sap\./.test(module)) {
 			candidate = "jQuery";
 		} else {
-			candidate = module;
+			candidate = module.replace(/\//g, ".");
 		}
+
+		const aUsedParamNames = this.defineCall.paramNames.slice();
+		aUsedParamNames.push("library");
 
 		// ensure local reference does neither contain invalid characters nor is
 		// a language keyword
-		candidate = VariableNameCreator.normalize(candidate);
+		candidate = VariableNameCreator.getUniqueParameterName(
+			aUsedParamNames, candidate);
 
 		// if the library module from a different library is imported, add a
 		// package to distinguish it more easily
-		if (p > 0 && candidate === "library" && this.defineCall &&
-			this.defineCall.name.indexOf(module.slice(0, p)) !== 0) {
-			let prefix = module.slice(module.lastIndexOf("/", p - 1) + 1, p);
-			if (prefix === "m") {
-				prefix = "mobile";
-			}
-			candidate = prefix + candidate.slice(0, 1).toUpperCase() +
-				candidate.slice(1);
-			p = module.lastIndexOf("/", p - 1);
-		}
-
-		while (this.defineCall.paramNames &&
-			   this.defineCall.paramNames.indexOf(candidate) >= 0) {
-			if (p > 0) {
-				let prefix =
-					module.slice(module.lastIndexOf("/", p - 1) + 1, p);
-				if (prefix === "m") {
-					prefix = "mobile";
-				}
-				candidate = prefix + candidate.slice(0, 1).toUpperCase() +
-					candidate.slice(1);
-				p = module.lastIndexOf("/", p - 1);
-			} else {
-				candidate = candidate + this.defineCall.paramNames.length;
-			}
+		if (candidate === "mLibrary") {
+			candidate = "mobileLibrary";
+			candidate = VariableNameCreator.getUniqueParameterName(
+				aUsedParamNames, candidate);
 		}
 
 		return candidate;

--- a/src/util/VariableNameCreator.ts
+++ b/src/util/VariableNameCreator.ts
@@ -3,19 +3,19 @@ import * as globals from "globals";
 const rAllowedStartCharacter = /^[A-Za-z_]/;
 const rInvalidChars = /[^A-Za-z0-9_]/g;
 const reservedJSLanguageKeywords = [
-	"abstract",   "arguments",	"await",	"boolean", "break",
-	"byte",		  "case",		  "catch",	"char",	"class",
-	"const",	  "continue",	 "debugger", "default", "delete",
-	"do",		  "double",		  "else",	 "enum",	"eval",
-	"export",	 "extends",	  "false",	"final",   "finally",
-	"float",	  "for",		  "function", "goto",	"if",
-	"implements", "import",		  "",		  "in",		 "instanceof",
-	"int",		  "interface",	"let",	  "long",	"native",
-	"new",		  "null",		  "package",  "private", "protected",
-	"public",	 "return",		  "short",	"static",  "super",
-	"switch",	 "synchronized", "this",	 "throw",   "throws",
-	"transient",  "true",		  "try",	  "typeof",  "var",
-	"void",		  "volatile",	 "while",	"with",	"yield"
+	"abstract",		"arguments", "await",	"boolean",	"break",
+	"byte",			"case",		 "catch",	"char",	   "class",
+	"const",		"continue",  "debugger", "default",	"delete",
+	"do",			"double",	"else",	 "enum",	   "eval",
+	"export",		"extends",   "false",	"final",	  "finally",
+	"float",		"for",		 "function", "goto",	   "if",
+	"implements",   "import",	"in",		 "instanceof", "int",
+	"interface",	"let",		 "long",	 "native",	 "new",
+	"null",			"package",   "private",  "protected",  "public",
+	"return",		"short",	 "static",   "super",	  "switch",
+	"synchronized", "this",		 "throw",	"throws",	 "transient",
+	"true",			"try",		 "typeof",   "var",		   "void",
+	"volatile",		"while",	 "with",	 "yield"
 ];
 const sapReservedKeywords = [ "sap" ];
 
@@ -45,6 +45,12 @@ const isUnique = function(aUsedVariables: string[], sName: string): boolean {
 	return !aUsedVariables.includes(sName) && !isReservedWord(sName);
 };
 
+/**
+ *
+ * @param aUsedVariables
+ * @param sName, e.g. Date
+ * @returns whether or not the name is a valid candidate
+ */
 const isValidIdentifierName = function(
 	aUsedVariables: string[], sName: string) {
 	return rAllowedStartCharacter.test(sName) &&
@@ -56,29 +62,41 @@ const replaceInvalidCharacters = function(sName) {
 	return sName.replace(rInvalidChars, "_");
 };
 
-
+/**
+ *
+ * @param aUsedVariables variable names which are already in use and should not
+ * be taken
+ * @param sName module name e.g. sap.ui.model.type.Date
+ * @param createLowercaseVariableName whether or not to enforce variable name
+ * starting with a lowercase character
+ * @returns unique variable name which is neither reserved nor taken
+ */
 const getUniqueName = function(
 	aUsedVariables: string[], sName: string,
-	createLowercaseVariableName?: boolean) {
-	// for param names
+	createLowercaseVariableName?: boolean): string {
+	// split the name and reverse, e.g. ["Date", "type", "model", "ui", "sap"]
 	const aNameSplitted = sName.split(".").reverse();
 	let sResultName = "";
 	const bCreateLowercaseVariableName =
 		createLowercaseVariableName || isLowerCase(aNameSplitted[0].charAt(0));
+
+	// make use of the whole namespace before applying prefix
 	for (let i = 0; i < aNameSplitted.length; i++) {
+		// concatenate name
 		sResultName = replaceInvalidCharacters(aNameSplitted[i]) +
 			capitalize(sResultName);
 
 		const candidate = bCreateLowercaseVariableName ?
 			decapitalize(sResultName) :
 			capitalize(sResultName);
+
+		// check if candidate is valid
 		if (isValidIdentifierName(aUsedVariables, candidate)) {
 			return candidate;
 		}
 	}
 
-	// add O's
-	// ooooooDate
+	// add prefix to make it unique
 	const prefixCharacter = bCreateLowercaseVariableName ? "o" : "O";
 	while (!isValidIdentifierName(aUsedVariables, sResultName)) {
 		sResultName = prefixCharacter + capitalize(sResultName);

--- a/src/util/VariableNameCreator.ts
+++ b/src/util/VariableNameCreator.ts
@@ -16,8 +16,85 @@ const reservedKeywords = [
 	"void",		  "volatile",	 "while",	"with",	"yield"
 ];
 const sapReservedKeywords = [ "sap" ];
+const reservedNativeTypes = [
+	"Array",
+	"ArrayBuffer",
+	"Atomics",
+	"BigInt",
+	"BigInt64Array",
+	"BigUint64Array",
+	"Boolean",
+	"DataView",
+	"Date",
+	"Error",
+	"EvalError",
+	"Float32Array",
+	"Float64Array",
+	"Function",
+	"Generator",
+	"GeneratorFunction",
+	"Infinity",
+	"Int16Array",
+	"Int32Array",
+	"Int8Array",
+	"InternalError",
+	"Intl",
+	"Intl.Collator",
+	"Intl.DateTimeFormat",
+	"Intl.Locale",
+	"Intl.NumberFormat",
+	"Intl.PluralRules",
+	"Intl.RelativeTimeFormat",
+	"JSON",
+	"Map",
+	"Math",
+	"NaN",
+	"Number",
+	"Object",
+	"Promise",
+	"Proxy",
+	"RangeError",
+	"ReferenceError",
+	"Reflect",
+	"RegExp",
+	"Set",
+	"SharedArrayBuffer",
+	"String",
+	"Symbol",
+	"SyntaxError",
+	"TypeError",
+	"TypedArray",
+	"URIError",
+	"Uint16Array",
+	"Uint32Array",
+	"Uint8Array",
+	"Uint8ClampedArray",
+	"WeakMap",
+	"WeakSet",
+	"WebAssembly",
+	"decodeURI()",
+	"decodeURIComponent()",
+	"encodeURI()",
+	"encodeURIComponent()",
+	"",
+	"eval()",
+	"globalThis",
+	"isFinite()",
+	"isNaN()",
+	"null",
+	"parseFloat()",
+	"parseInt()"
+];
 
-
+/**
+ * In case the candidate is already taken, the variable name gets prefixed with
+ * 'o' until it is unique
+ *
+ * @param aUsedVariables Existing variable names which are already in use, e.g.
+ * Component
+ * @param sName Name of the candidate, e.g. sap.ui.core.Component
+ * @returns A unique variable name
+ */
 export function getUniqueVariableName(aUsedVariables: string[], sName: string) {
 	let sResultName = "";
 	sName.split(".").reverse().some((sNamePart) => {
@@ -63,7 +140,8 @@ export function normalize(sVariableName: string): string {
 
 	// ensure there is no keyword match
 	while (reservedKeywords.includes(sVariableName) ||
-		   sapReservedKeywords.includes(sVariableName)) {
+		   sapReservedKeywords.includes(sVariableName) ||
+		   reservedNativeTypes.includes(sVariableName)) {
 		sVariableName = "o" + capitalize(sVariableName);
 	}
 

--- a/src/util/VariableNameCreator.ts
+++ b/src/util/VariableNameCreator.ts
@@ -72,18 +72,17 @@ const reservedNativeTypes = [
 	"WeakMap",
 	"WeakSet",
 	"WebAssembly",
-	"decodeURI()",
-	"decodeURIComponent()",
-	"encodeURI()",
-	"encodeURIComponent()",
-	"",
-	"eval()",
+	"decodeURI",
+	"decodeURIComponent",
+	"encodeURI",
+	"encodeURIComponent",
+	"eval",
 	"globalThis",
-	"isFinite()",
-	"isNaN()",
+	"isFinite",
+	"isNaN",
 	"null",
-	"parseFloat()",
-	"parseInt()"
+	"parseFloat",
+	"parseInt"
 ];
 
 /**

--- a/src/util/VariableNameCreator.ts
+++ b/src/util/VariableNameCreator.ts
@@ -16,6 +16,12 @@ const reservedKeywords = [
 	"void",		  "volatile",	 "while",	"with",	"yield"
 ];
 const sapReservedKeywords = [ "sap" ];
+
+const reservedBrowserTypes = [
+	"Element", "History", "Node", "Option", "Performance", "Plugin", "Range",
+	"Request", "Response", "Storage", "StyleSheet", "Text", "Touch",
+	"WebSocket", "Worker"
+];
 const reservedNativeTypes = [
 	"Array",
 	"ArrayBuffer",
@@ -71,19 +77,77 @@ const reservedNativeTypes = [
 	"Uint8ClampedArray",
 	"WeakMap",
 	"WeakSet",
-	"WebAssembly",
-	"decodeURI",
-	"decodeURIComponent",
-	"encodeURI",
-	"encodeURIComponent",
-	"eval",
-	"globalThis",
-	"isFinite",
-	"isNaN",
-	"null",
-	"parseFloat",
-	"parseInt"
+	"WebAssembly"
 ];
+const reservedNativeFunctions = [
+	"decodeURI", "decodeURIComponent", "encodeURI", "encodeURIComponent",
+	"globalThis", "isFinite", "isNaN", "parseFloat", "parseInt"
+];
+
+export function getUniqueParameterName(
+	aUsedVariables: string[], sName: string) {
+	return getUniqueName(aUsedVariables, sName);
+}
+
+const getUniqueNameDecapitalized = function(
+	aUsedVariables: string[], sName: string) {
+	return getUniqueName(aUsedVariables, sName, true);
+};
+
+const isLowerCase = function(sChar) {
+	return sChar === sChar.toLowerCase();
+};
+
+/**
+ *
+ * @param aUsedVariables
+ * @param sName
+ */
+const isUnique = function(aUsedVariables: string[], sName: string): boolean {
+	return !aUsedVariables.includes(sName) && !isReservedWord(sName);
+};
+
+const isValidIdentifierName = function(
+	aUsedVariables: string[], sName: string) {
+	return rAllowedStartCharacter.test(sName) &&
+		isUnique(aUsedVariables, sName);
+};
+
+const replaceInvalidCharacters = function(sName) {
+	sName = camelize(sName);
+	return sName.replace(rInvalidChars, "_");
+};
+
+
+const getUniqueName = function(
+	aUsedVariables: string[], sName: string,
+	createLowercaseVariableName?: boolean) {
+	// for param names
+	const aNameSplitted = sName.split(".").reverse();
+	let sResultName = "";
+	const bCreateLowercaseVariableName =
+		createLowercaseVariableName || isLowerCase(aNameSplitted[0].charAt(0));
+	for (let i = 0; i < aNameSplitted.length; i++) {
+		sResultName = replaceInvalidCharacters(aNameSplitted[i]) +
+			capitalize(sResultName);
+
+		const candidate = bCreateLowercaseVariableName ?
+			decapitalize(sResultName) :
+			capitalize(sResultName);
+		if (isValidIdentifierName(aUsedVariables, candidate)) {
+			return candidate;
+		}
+	}
+
+	// add O's
+	// ooooooDate
+	const prefixCharacter = bCreateLowercaseVariableName ? "o" : "O";
+	while (!isValidIdentifierName(aUsedVariables, sResultName)) {
+		sResultName = prefixCharacter + capitalize(sResultName);
+	}
+
+	return sResultName;
+};
 
 /**
  * In case the candidate is already taken, the variable name gets prefixed with
@@ -92,71 +156,52 @@ const reservedNativeTypes = [
  * @param aUsedVariables Existing variable names which are already in use, e.g.
  * Component
  * @param sName Name of the candidate, e.g. sap.ui.core.Component
- * @returns A unique variable name
+ * @returns A unique variable name starting with a lowercase character
  */
 export function getUniqueVariableName(aUsedVariables: string[], sName: string) {
-	let sResultName = "";
-	sName.split(".").reverse().some((sNamePart) => {
-		sResultName = decapitalize(sNamePart) + capitalize(sResultName);
-		if (!aUsedVariables.includes(normalize(sResultName))) {
-			sResultName = normalize(sResultName);
-			return true;
-		}
-		return false;
-	});
-
-	while (aUsedVariables.includes(sResultName)) {
-		sResultName = "o" + normalize(capitalize(sResultName));
-	}
-
-	return sResultName;
+	return getUniqueNameDecapitalized(aUsedVariables, sName);
 }
+
+const isReservedWord = function(sVariableName: string) {
+	return reservedKeywords.includes(sVariableName) ||
+		sapReservedKeywords.includes(sVariableName) ||
+		reservedBrowserTypes.includes(sVariableName) ||
+		reservedNativeFunctions.includes(sVariableName) ||
+		reservedNativeTypes.includes(sVariableName);
+};
 
 /**
- *
- * @param sVariableName the input variable name
- * @returns variable name which neither contain invalid characters nor is a
- * language keyword
+ * @param str input string, e.g. "asd"
+ * @returns {string} first character being upper case, e.g. "Asd"
  */
-export function normalize(sVariableName: string): string {
-	// variable name must start with a letter or an underscore
-	// if not prepend "s" for string
-	if (!rAllowedStartCharacter.test(sVariableName)) {
-		sVariableName = "o" + capitalize(sVariableName);
-	}
-
-	// prettify variable name by removing dashes
-	if (sVariableName.includes("-")) {
-		const rCamelCase = /-(.)/ig;
-		sVariableName =
-			sVariableName.replace(rCamelCase, function(sMatch, sChar) {
-				return sChar.toUpperCase();
-			});
-	}
-
-	// replace invalid chars
-	sVariableName = sVariableName.replace(rInvalidChars, "_");
-
-	// ensure there is no keyword match
-	while (reservedKeywords.includes(sVariableName) ||
-		   sapReservedKeywords.includes(sVariableName) ||
-		   reservedNativeTypes.includes(sVariableName)) {
-		sVariableName = "o" + capitalize(sVariableName);
-	}
-
-	return sVariableName;
-}
-
-function capitalize(str: string): string {
+const capitalize = function(str: string): string {
 	if (str.length < 1) {
 		return "";
 	}
 	return str[0].toUpperCase() + str.substring(1);
-}
+};
 
-function decapitalize(str: string): string {
+/**
+ * @param str input string, e.g. "asd-fgh"
+ * @returns {string} every character after the dash is uppercase and dash gets removed, e.g. "asdFgh"
+ */
+const camelize = function(str: string): string {
+	if (str.includes("-")) {
+		const rCamelCase = /-(.)/ig;
+		return str.replace(rCamelCase, function(sMatch, sChar) {
+			return sChar.toUpperCase();
+		});
+	}
+	return str;
+};
+
+/**
+ * @param str input string, e.g. "ASD"
+ * @returns {string} first character being lower case, e.g. "aSD"
+ */
+const decapitalize = function(str: string): string {
 	if (str.length < 1) {
 		return "";
 	}
 	return str[0].toLowerCase() + str.substring(1);
-}
+};

--- a/src/util/VariableNameCreator.ts
+++ b/src/util/VariableNameCreator.ts
@@ -1,6 +1,8 @@
+import * as globals from "globals";
+
 const rAllowedStartCharacter = /^[A-Za-z_]/;
 const rInvalidChars = /[^A-Za-z0-9_]/g;
-const reservedKeywords = [
+const reservedJSLanguageKeywords = [
 	"abstract",   "arguments",	"await",	"boolean", "break",
 	"byte",		  "case",		  "catch",	"char",	"class",
 	"const",	  "continue",	 "debugger", "default", "delete",
@@ -17,72 +19,8 @@ const reservedKeywords = [
 ];
 const sapReservedKeywords = [ "sap" ];
 
-const reservedBrowserTypes = [
-	"Element", "History", "Node", "Option", "Performance", "Plugin", "Range",
-	"Request", "Response", "Storage", "StyleSheet", "Text", "Touch",
-	"WebSocket", "Worker"
-];
-const reservedNativeTypes = [
-	"Array",
-	"ArrayBuffer",
-	"Atomics",
-	"BigInt",
-	"BigInt64Array",
-	"BigUint64Array",
-	"Boolean",
-	"DataView",
-	"Date",
-	"Error",
-	"EvalError",
-	"Float32Array",
-	"Float64Array",
-	"Function",
-	"Generator",
-	"GeneratorFunction",
-	"Infinity",
-	"Int16Array",
-	"Int32Array",
-	"Int8Array",
-	"InternalError",
-	"Intl",
-	"Intl.Collator",
-	"Intl.DateTimeFormat",
-	"Intl.Locale",
-	"Intl.NumberFormat",
-	"Intl.PluralRules",
-	"Intl.RelativeTimeFormat",
-	"JSON",
-	"Map",
-	"Math",
-	"NaN",
-	"Number",
-	"Object",
-	"Promise",
-	"Proxy",
-	"RangeError",
-	"ReferenceError",
-	"Reflect",
-	"RegExp",
-	"Set",
-	"SharedArrayBuffer",
-	"String",
-	"Symbol",
-	"SyntaxError",
-	"TypeError",
-	"TypedArray",
-	"URIError",
-	"Uint16Array",
-	"Uint32Array",
-	"Uint8Array",
-	"Uint8ClampedArray",
-	"WeakMap",
-	"WeakSet",
-	"WebAssembly"
-];
-const reservedNativeFunctions = [
-	"decodeURI", "decodeURIComponent", "encodeURI", "encodeURIComponent",
-	"globalThis", "isFinite", "isNaN", "parseFloat", "parseInt"
-];
+const reservedBrowserTypes = Object.keys(globals.browser);
+const reservedNativeTypes = Object.keys(globals.builtin);
 
 export function getUniqueParameterName(
 	aUsedVariables: string[], sName: string) {
@@ -163,10 +101,9 @@ export function getUniqueVariableName(aUsedVariables: string[], sName: string) {
 }
 
 const isReservedWord = function(sVariableName: string) {
-	return reservedKeywords.includes(sVariableName) ||
+	return reservedJSLanguageKeywords.includes(sVariableName) ||
 		sapReservedKeywords.includes(sVariableName) ||
 		reservedBrowserTypes.includes(sVariableName) ||
-		reservedNativeFunctions.includes(sVariableName) ||
 		reservedNativeTypes.includes(sVariableName);
 };
 

--- a/test/amdCleanup/dateType.api.json
+++ b/test/amdCleanup/dateType.api.json
@@ -1,0 +1,26 @@
+{
+	"$schema-ref": "http://schemas.sap.com/sapui5/designtime/api.json/1.0",
+	"version": "1.60.0",
+	"library": "sap.ui.core",
+	"symbols": [
+		{
+			"kind": "class",
+			"name": "sap.ui.model.type.Date",
+			"basename": "Date",
+			"resource": "sap/ui/model/type/Date.js",
+			"module": "sap/ui/model/type/Date",
+			"export": "",
+			"static": true,
+			"visibility": "public",
+			"extends": "sap.ui.model.SimpleType",
+			"description": "This class represents date simple types.",
+			"ui5-metadata": {
+				"stereotype": "object"
+			},
+			"constructor": {
+				"visibility": "public"
+			}
+		}
+
+	]
+}

--- a/test/amdCleanup/dateType.expected.js
+++ b/test/amdCleanup/dateType.expected.js
@@ -2,9 +2,10 @@ sap.ui.define([
     "jquery.sap.global",
     "sap/ui/core/UIComponent",
     "sap/ui/base/Object",
-	"sap/m/MessageBox",
-	"sap/ui/model/type/Date"
-], function(jQuery, UIComponent, UI5Object, MessageBox, TypeDate) {
+    "sap/m/MessageBox",
+    "sap/ui/model/type/Date"
+],
+function(jQuery, UIComponent, UI5Object, MessageBox, TypeDate) {
 	"use strict";
 
 	var oSuccessHandler = UI5Object.extend("mine.controller.SuccessHandler", {

--- a/test/amdCleanup/dateType.expected.js
+++ b/test/amdCleanup/dateType.expected.js
@@ -1,0 +1,20 @@
+sap.ui.define([
+    "jquery.sap.global",
+    "sap/ui/core/UIComponent",
+    "sap/ui/base/Object",
+	"sap/m/MessageBox",
+	"sap/ui/model/type/Date"
+], function(jQuery, UIComponent, UI5Object, MessageBox, TypeDate) {
+	"use strict";
+
+	var oSuccessHandler = UI5Object.extend("mine.controller.SuccessHandler", {
+		constructor: function (oComponent) {
+		}
+	});
+
+	oSuccessHandler.prototype.successMessagePopover = function(oComponent) {
+		var oDate = new TypeDate();
+		return oDate;
+
+	};
+}, true);

--- a/test/amdCleanup/dateType.js
+++ b/test/amdCleanup/dateType.js
@@ -10,5 +10,6 @@ function (jQuery, UIComponent, UI5Object, MessageBox) {
 	oSuccessHandler.prototype.successMessagePopover = function(oComponent) {
 		var oDate = new sap.ui.model.type.Date();
 		return oDate;
+
 	};
 }, true);

--- a/test/amdCleanup/dateType.js
+++ b/test/amdCleanup/dateType.js
@@ -1,0 +1,14 @@
+sap.ui.define(["jquery.sap.global", "sap/ui/core/UIComponent", "sap/ui/base/Object", "sap/m/MessageBox"],
+function (jQuery, UIComponent, UI5Object, MessageBox) {
+	"use strict";
+
+	var oSuccessHandler = UI5Object.extend("mine.controller.SuccessHandler", {
+		constructor: function (oComponent) {
+		}
+	});
+
+	oSuccessHandler.prototype.successMessagePopover = function(oComponent) {
+		var oDate = new sap.ui.model.type.Date();
+		return oDate;
+	};
+}, true);

--- a/test/amdCleanup/reservedKeywords.expected.js
+++ b/test/amdCleanup/reservedKeywords.expected.js
@@ -1,9 +1,9 @@
 sap.ui.define([], function() {
     "use strict";
 
-	var oConst = {
+	var timePickerConst = {
 		x: 47
 	};
 
-	return oConst;
+	return timePickerConst;
 }, true);

--- a/test/amdCleanupTest.ts
+++ b/test/amdCleanupTest.ts
@@ -481,6 +481,17 @@ describe("AmdCleaner ui52amd", function() {
 		 api : { "sap.ui.core" : rootDir + "amdCleanup/varvar.api.json" }
 	 },
 	 {
+		 title : "sap.ui.model.type.Date should be replaced correctly",
+		 sourceCodeFileName : "amdCleanup/dateType.js",
+		 expectedCodeFileName : "amdCleanup/dateType.expected.js",
+		 modified : true,
+		 amdSettings : {
+			 addTodoForUnsafeReplacements : false,
+			 onlySafeReplacements : false
+		 },
+		 api : { "sap.ui.core" : rootDir + "amdCleanup/dateType.api.json" }
+	 },
+	 {
 		 title : "duplicate Export variable (duplicateExportVar)",
 		 sourceCodeFileName : "amdCleanup/duplicateExportVar.js",
 		 expectedCodeFileName : "amdCleanup/duplicateExportVar.expected.js",
@@ -972,6 +983,7 @@ describe("AmdCleaner ui52amd", function() {
 		const pathToApiJSON = rootDir +
 			(fixture.apiFileName ? fixture.apiFileName :
 								   "amdCleanup/_generic.api.json");
+
 		it(fixture.title, function(done) {
 			const sourceCodeFile = rootDir + fixture.sourceCodeFileName;
 			const expectedContent =

--- a/test/amdCleanupTest.ts
+++ b/test/amdCleanupTest.ts
@@ -484,6 +484,14 @@ describe("AmdCleaner ui52amd", function() {
 		 title : "sap.ui.model.type.Date should be replaced correctly",
 		 sourceCodeFileName : "amdCleanup/dateType.js",
 		 expectedCodeFileName : "amdCleanup/dateType.expected.js",
+		 logs : [
+			 "debug: found define call at position 0",
+			 "debug: found define call at position 0",
+			 "debug:   add import TypeDate <= sap/ui/model/type/Date",
+			 "debug: 11: Add dependency for sap.ui.model.type.Date",
+			 "debug: 11:   replace sap.ui.model.type.Date with TypeDate",
+			 "debug: 11: Replace occurrence of TypeDate"
+		 ],
 		 modified : true,
 		 amdSettings : {
 			 addTodoForUnsafeReplacements : false,
@@ -745,8 +753,8 @@ describe("AmdCleaner ui52amd", function() {
 			 "debug: 1: remove jQuery.sap.declare(sap.m.sample.TimePicker.const)",
 			 "debug: 1: Create empty define call",
 			 "debug: 1: remove jQuery.sap.declare(sap.m.sample.TimePicker.const)",
-			 "debug: 3: Added variable oConst",
-			 "debug: Added return statement of oConst",
+			 "debug: 3: Added variable timePickerConst",
+			 "debug: Added return statement of timePickerConst",
 			 "debug: Added true for global export"
 		 ],
 		 modified : true,

--- a/test/util/VariableNameCreatorTest.ts
+++ b/test/util/VariableNameCreatorTest.ts
@@ -4,101 +4,123 @@ const assert = require("assert");
 
 describe("VariableNameCreator", function() {
 	it("getUniqueVariableName special chars", function() {
-		assert.equal(
+		assert.strictEqual(
 			VariableNameCreator.getUniqueVariableName([], "myVariable"),
-			"myVariable");
-		assert.equal(
-			VariableNameCreator.getUniqueVariableName([], "1myVariable"),
-			"o1myVariable");
-		assert.equal(
+			"myVariable", "not in use nor keyword");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueVariableName([], "5myVariable"),
+			"o5myVariable", "starts with a number therefore prefix it");
+		assert.strictEqual(
 			VariableNameCreator.getUniqueVariableName([], "_myVariable"),
-			"_myVariable");
-		assert.equal(
-			VariableNameCreator.getUniqueVariableName([], "my7%var"),
-			"my7_var");
-		assert.equal(
-			VariableNameCreator.getUniqueVariableName([], "var"), "oVar");
-		assert.equal(
+			"_myVariable", "underscore is valid variable name start character");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueVariableName([], "my7%var"), "my7_var",
+			"% is invalid character which gets replaced with underscore");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueVariableName([], "var"), "oVar",
+			"var is a reserved keyword");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueVariableName([], "parseInt"),
+			"oParseInt", "parseInt is a reserved builtin function");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueVariableName([], "sap"), "oSap",
+			"sap is reserved for SAP");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueVariableName([], "navigator"),
+			"oNavigator", "navigator is a reserved browser type");
+		assert.strictEqual(
 			VariableNameCreator.getUniqueVariableName([], "jquery-ui"),
-			"jqueryUi");
+			"jqueryUi", "dashes in name should lead to camelize");
 	});
 
 	it("getUniqueVariableName", function() {
-		assert.equal(
-			VariableNameCreator.getUniqueVariableName([ "yoo" ], "yoo"),
-			"oYoo");
-		assert.equal(
-			VariableNameCreator.getUniqueVariableName([], "Yoo"), "yoo");
-		assert.equal(
+		assert.strictEqual(
+			VariableNameCreator.getUniqueVariableName([ "yoo" ], "yoo"), "oYoo",
+			"yoo variable is already taken therefore add prefix");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueVariableName([], "Yoo"), "yoo",
+			"variables start with lowercase char");
+		assert.strictEqual(
 			VariableNameCreator.getUniqueVariableName(
 				[ "arguments" ], "arguments"),
-			"oArguments");
-		assert.equal(
+			"oArguments", "arguments is already taken");
+		assert.strictEqual(
 			VariableNameCreator.getUniqueVariableName([ "asd" ], "arguments"),
-			"oArguments");
-		assert.equal(
+			"oArguments", "arguments is a js language reserved word");
+		assert.strictEqual(
 			VariableNameCreator.getUniqueVariableName([ "yoo" ], "asd.yey.yoo"),
-			"yeyYoo");
-		assert.equal(
+			"yeyYoo", "yoo is already excluded therefore add namespace");
+		assert.strictEqual(
 			VariableNameCreator.getUniqueVariableName(
 				[ "yeyYoo", "yoo" ], "asd.yey.yoo"),
-			"asdYeyYoo");
-		assert.equal(
+			"asdYeyYoo",
+			"yoo and yeyYoo are already excluded therefore add namespace");
+		assert.strictEqual(
 			VariableNameCreator.getUniqueVariableName(
 				[ "asdYeyYoo", "yeyYoo", "yoo" ], "asd.yey.yoo"),
-			"oAsdYeyYoo");
+			"oAsdYeyYoo",
+			"yoo and yeyYoo and asdYeyYoo are already excluded therefore add namespace and add prefix");
 	});
 
 	it("getUniqueParameterName", function() {
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName([ "yoo" ], "yoo"),
-			"oYoo");
+			"oYoo", "yoo variable is already taken therefore add prefix");
 		assert.strictEqual(
-			VariableNameCreator.getUniqueParameterName([], "Yoo"), "Yoo");
+			VariableNameCreator.getUniqueParameterName([], "yoo"), "yoo",
+			"parameter name taken as is");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName([], "Yoo"), "Yoo",
+			"parameter name taken as is");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName(
 				[ "arguments" ], "arguments"),
-			"oArguments");
+			"oArguments", "arguments is already taken");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName([ "asd" ], "arguments"),
-			"oArguments");
+			"oArguments", "arguments is a js language reserved word");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName(
 				[ "yoo" ], "asd.yey.yoo"),
-			"yeyYoo");
+			"yeyYoo", "yoo is already excluded therefore add namespace");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName(
 				[ "yeyYoo", "yoo" ], "asd.yey.yoo"),
-			"asdYeyYoo");
+			"asdYeyYoo",
+			"yoo and yeyYoo are already excluded therefore add namespace");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName(
 				[ "asdYeyYoo", "yeyYoo", "yoo" ], "asd.yey.yoo"),
-			"oAsdYeyYoo");
+			"oAsdYeyYoo",
+			"yoo and yeyYoo and asdYeyYoo are already excluded therefore add namespace and add prefix");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName([], "Date"), "ODate",
 			"Add O to the Date since it is a reserved native type");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName([ "ODate" ], "Date"),
-			"OODate");
+			"OODate",
+			"Add O to the Date since it is a reserved native type and add additional O since is already in use");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName(
 				[ "oDate" ], "sap.ui.model.type.Date"),
-			"TypeDate");
+			"TypeDate", "Use namespace");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName(
 				[], "sap.ui.model.type.Date"),
-			"TypeDate");
+			"TypeDate", "Use namespace");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName(
 				[ "TypeDate" ], "sap.ui.model.type.Date"),
-			"ModelTypeDate");
+			"ModelTypeDate", "Use namespace to make it unique");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName(
 				[ "typeSwitch" ], "sap.ui.model.type.switch"),
-			"modelTypeSwitch");
+			"modelTypeSwitch",
+			"Use namespace to make it unique (lowercase scenario)");
 		assert.strictEqual(
 			VariableNameCreator.getUniqueParameterName(
 				[ "typeDate", "date" ], "sap.ui.model.type.date"),
-			"modelTypeDate");
+			"modelTypeDate",
+			"Use namespace to make it unique (lowercase scenario)");
 	});
 });

--- a/test/util/VariableNameCreatorTest.ts
+++ b/test/util/VariableNameCreatorTest.ts
@@ -3,15 +3,24 @@ import * as VariableNameCreator from "../../src/util/VariableNameCreator";
 const assert = require("assert");
 
 describe("VariableNameCreator", function() {
-	it("guessName", function() {
-		assert.equal(VariableNameCreator.normalize("myVariable"), "myVariable");
+	it("getUniqueVariableName special chars", function() {
 		assert.equal(
-			VariableNameCreator.normalize("1myVariable"), "o1myVariable");
+			VariableNameCreator.getUniqueVariableName([], "myVariable"),
+			"myVariable");
 		assert.equal(
-			VariableNameCreator.normalize("_myVariable"), "_myVariable");
-		assert.equal(VariableNameCreator.normalize("my7%var"), "my7_var");
-		assert.equal(VariableNameCreator.normalize("var"), "oVar");
-		assert.equal(VariableNameCreator.normalize("jquery-ui"), "jqueryUi");
+			VariableNameCreator.getUniqueVariableName([], "1myVariable"),
+			"o1myVariable");
+		assert.equal(
+			VariableNameCreator.getUniqueVariableName([], "_myVariable"),
+			"_myVariable");
+		assert.equal(
+			VariableNameCreator.getUniqueVariableName([], "my7%var"),
+			"my7_var");
+		assert.equal(
+			VariableNameCreator.getUniqueVariableName([], "var"), "oVar");
+		assert.equal(
+			VariableNameCreator.getUniqueVariableName([], "jquery-ui"),
+			"jqueryUi");
 	});
 
 	it("getUniqueVariableName", function() {
@@ -38,5 +47,58 @@ describe("VariableNameCreator", function() {
 			VariableNameCreator.getUniqueVariableName(
 				[ "asdYeyYoo", "yeyYoo", "yoo" ], "asd.yey.yoo"),
 			"oAsdYeyYoo");
+	});
+
+	it("getUniqueParameterName", function() {
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName([ "yoo" ], "yoo"),
+			"oYoo");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName([], "Yoo"), "Yoo");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName(
+				[ "arguments" ], "arguments"),
+			"oArguments");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName([ "asd" ], "arguments"),
+			"oArguments");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName(
+				[ "yoo" ], "asd.yey.yoo"),
+			"yeyYoo");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName(
+				[ "yeyYoo", "yoo" ], "asd.yey.yoo"),
+			"asdYeyYoo");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName(
+				[ "asdYeyYoo", "yeyYoo", "yoo" ], "asd.yey.yoo"),
+			"oAsdYeyYoo");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName([], "Date"), "ODate",
+			"Add O to the Date since it is a reserved native type");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName([ "ODate" ], "Date"),
+			"OODate");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName(
+				[ "oDate" ], "sap.ui.model.type.Date"),
+			"TypeDate");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName(
+				[], "sap.ui.model.type.Date"),
+			"TypeDate");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName(
+				[ "TypeDate" ], "sap.ui.model.type.Date"),
+			"ModelTypeDate");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName(
+				[ "typeSwitch" ], "sap.ui.model.type.switch"),
+			"modelTypeSwitch");
+		assert.strictEqual(
+			VariableNameCreator.getUniqueParameterName(
+				[ "typeDate", "date" ], "sap.ui.model.type.date"),
+			"modelTypeDate");
 	});
 });


### PR DESCRIPTION
Fixes #10

Variable names and parameter names now exclude js builtin types as well as browser globals.