### PR TITLE
[FEATURE] Program exit code for analyze like eslint

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,5 +6,7 @@ process.on("unhandledRejection", (reason, p) => {
 });
 
 CLI.start().catch((err) => {
-	throw err;
+	console.error(err.message);
+	// error causes program to exit with error status code
+	process.exit(1);
 });

--- a/defaultConfig/addMissingDependencies.config.json
+++ b/defaultConfig/addMissingDependencies.config.json
@@ -5,7 +5,7 @@
 				"newModulePath": "sap/ui/dom/jquery/cursorPos",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"cursorPos\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -13,7 +13,7 @@
 				"newModulePath": "sap/ui/dom/jquery/control",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"control\"",
-				"finder": "JQueryFunctionExtensionFinder",
+				"finder": "JQueryFunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -21,7 +21,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Focusable",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"firstFocusableDomRef\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -29,7 +29,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Focusable",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"lastFocusableDomRef\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -37,7 +37,7 @@
 				"newModulePath": "sap/ui/dom/jquery/getSelectedText",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"getSelectedText\"",
-				"finder": "JQueryFunctionExtensionFinder",
+				"finder": "JQueryFunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -45,7 +45,7 @@
 				"newModulePath": "sap/ui/dom/jquery/hasTabIndex",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"hasTabIndex\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -53,7 +53,7 @@
 				"newModulePath": "sap/ui/dom/jquery/parentByAttribute",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"parentByAttribute\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -61,7 +61,7 @@
 				"newModulePath": "sap/ui/dom/jquery/rect",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"rect\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -69,7 +69,7 @@
 				"newModulePath": "sap/ui/dom/jquery/rectContains",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"rectContains\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -77,7 +77,7 @@
 				"newModulePath": "sap/ui/dom/jquery/scrollLeftRTL",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"scrollLeftRTL\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -85,7 +85,7 @@
 				"newModulePath": "sap/ui/dom/jquery/scrollRightRTL",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"scrollRightRTL\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -93,7 +93,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Selection",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"disableSelection\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -101,7 +101,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Selection",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"enableSelection\"",
-				"finder": "FunctionExtensionFinder",
+				"finder": "FunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -109,7 +109,7 @@
 				"newModulePath": "sap/ui/dom/jquery/selectText",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"selectText\"",
-				"finder": "JQueryFunctionExtensionFinder",
+				"finder": "JQueryFunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -117,7 +117,7 @@
 				"newModulePath": "sap/ui/dom/jquery/zIndex",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"zIndex\"",
-				"finder": "JQueryFunctionExtensionFinder",
+				"finder": "JQueryFunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -125,7 +125,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Aria",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"addAriaLabelledBy\"",
-				"finder": "JQueryFunctionExtensionFinder",
+				"finder": "JQueryFunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -133,7 +133,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Aria",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"removeAriaLabelledBy\"",
-				"finder": "JQueryFunctionExtensionFinder",
+				"finder": "JQueryFunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -141,7 +141,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Aria",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"addAriaDescribedBy\"",
-				"finder": "JQueryFunctionExtensionFinder",
+				"finder": "JQueryFunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			},
@@ -149,7 +149,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Aria",
 				"replacer": "AddComment",
 				"commentText": " jQuery Plugin \"removeAriaDescribedBy\"",
-				"finder": "JQueryFunctionExtensionFinder",
+				"finder": "JQueryFunctionExtensionFinderWithDependencyCheck",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
 			}
@@ -159,7 +159,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Selectors",
 				"replacer": "AddComment",
 				"commentText": " jQuery custom selectors \":sapTabbable\"",
-				"finder": "CallWithArgumentFinder",
+				"finder": "CallWithArgumentFinderWithDependencyCheck",
 				"finderIncludesName": ":sapTabbable",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
@@ -168,7 +168,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Selectors",
 				"replacer": "AddComment",
 				"commentText": " jQuery custom selectors \":focusable\"",
-				"finder": "CallWithArgumentFinder",
+				"finder": "CallWithArgumentFinderWithDependencyCheck",
 				"finderIncludesName": ":focusable",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
@@ -177,7 +177,7 @@
 				"newModulePath": "sap/ui/dom/jquery/Selectors",
 				"replacer": "AddComment",
 				"commentText": " jQuery custom selectors \":sapFocusable\"",
-				"finder": "CallWithArgumentFinder",
+				"finder": "CallWithArgumentFinderWithDependencyCheck",
 				"finderIncludesName": ":sapFocusable",
 				"extender": "AddUnusedImportWithComment",
 				"version": "^1.58.0"
@@ -186,10 +186,11 @@
 	},
 	"finders": {
 		"FunctionExtensionFinder": "tasks/helpers/finders/FunctionExtensionFinder.js",
+		"FunctionExtensionFinderWithDependencyCheck": "tasks/helpers/finders/FunctionExtensionFinderWithDependencyCheck.js",
 		"JQueryFunctionExtensionFinder": "tasks/helpers/finders/JQueryFunctionExtensionFinder.js",
+		"JQueryFunctionExtensionFinderWithDependencyCheck": "tasks/helpers/finders/JQueryFunctionExtensionFinderWithDependencyCheck.js",
 		"CallWithArgumentFinder": "tasks/helpers/finders/CallWithArgumentFinder.js",
-		"JQuerySapExtendFinder": "tasks/helpers/finders/JQuerySapExtendFinder.js",
-		"AssignReplacementFinder": "tasks/helpers/finders/AssignReplacementFinder.js"
+		"CallWithArgumentFinderWithDependencyCheck": "tasks/helpers/finders/CallWithArgumentFinderWithDependencyCheck.js"
 	},
 	"extenders": {
 		"AddUnusedImport": "tasks/helpers/extenders/AddUnusedImport.js",

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,6 +1,6 @@
 # Commandline-Interface (CLI)
 
-An overview of the cli commands will be printed by executing 
+An overview of the cli commands will be printed by executing
 ```shell
 ui5-migration --help
 ```
@@ -17,6 +17,34 @@ ui5-migration [command] [input-paths] [options]
 Multiple paths need to be separated by spaces.
 
 ```[options]``` have to be named explicitly.
+
+## Commands
+
+### ```analyze```
+
+The ```analyze``` command will exit with the following codes.
+
+Exit Code 0:
+
+* There are no findings
+
+Exit Code 1:
+
+* in case there are some findings
+* No files are found
+
+### ```migrate```
+
+The ```migrate``` command will exit with the following codes.
+
+Exit Code 0:
+
+* There are no findings
+* The migration has been performed successfully
+
+Exit Code 1:
+
+* No files are found
 
 ## Paths (input-paths)
 

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -22,7 +22,7 @@ export interface Finder {
 	 * @param {object} config configuration object which can be enriched as it gets
 	 * passed through to replacer and extender
 	 * @param {string} sConfigName the input config name, set it within the
-	 * @param {SapUiDefineCall} defineCall the definecall
+	 * @param {SapUiDefineCall} defineCall the definecall, e.g. can be used to perform dependency checks
 	 * @returns {FinderResult} to indicate a finding
 	 */
 	find(

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -22,9 +22,12 @@ export interface Finder {
 	 * @param {object} config configuration object which can be enriched as it gets
 	 * passed through to replacer and extender
 	 * @param {string} sConfigName the input config name, set it within the
+	 * @param {SapUiDefineCall} defineCall the definecall
 	 * @returns {FinderResult} to indicate a finding
 	 */
-	find(node: ESTree.Node, config: {}, sConfigName: string): FinderResult;
+	find(
+		node: ESTree.Node, config: {}, sConfigName: string,
+		defineCall: SapUiDefineCall): FinderResult;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,7 +324,9 @@ export async function migrate(oArgs: IndexArgs): Promise<{}> {
 	oTaskRunnerReporter.reportCollected(ReportLevel.INFO);
 	const result = oTaskRunnerReporter.finalize();
 	if (bDryRun && oTaskRunnerReporter.getFindings().length > 0) {
-		console.error(oTaskRunnerReporter.getFindings());
+		oTaskRunnerReporter.report(
+			ReportLevel.TRACE,
+			`Findings: ${oTaskRunnerReporter.getFindings().join("\n")}`);
 		throw new Error("Found entries to be migrated!");
 	}
 	return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,8 +325,8 @@ export async function migrate(oArgs: IndexArgs): Promise<{}> {
 	const result = oTaskRunnerReporter.finalize();
 	if (bDryRun && oTaskRunnerReporter.getFindings().length > 0) {
 		oTaskRunnerReporter.report(
-			ReportLevel.TRACE,
-			`Findings: ${oTaskRunnerReporter.getFindings().join("\n")}`);
+			ReportLevel.WARNING,
+			`Findings: ${JSON.stringify(oTaskRunnerReporter.getFindings())}`);
 		throw new Error("Found entries to be migrated!");
 	}
 	return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,7 +267,7 @@ export async function migrate(oArgs: IndexArgs): Promise<{}> {
 	if (aFiles.length === 0) {
 		oTaskRunnerReporter.report(ReportLevel.INFO, "No files found!");
 		// exit
-		return undefined;
+		throw new Error("No files found!");
 	}
 
 	// execute migration
@@ -322,5 +322,10 @@ export async function migrate(oArgs: IndexArgs): Promise<{}> {
 	oTaskRunnerReporter.report(
 		ReportLevel.INFO, `Finished in ${endTime[0]}s ${endTime[1]}ms`);
 	oTaskRunnerReporter.reportCollected(ReportLevel.INFO);
-	return oTaskRunnerReporter.finalize();
+	const result = oTaskRunnerReporter.finalize();
+	if (bDryRun && oTaskRunnerReporter.getFindings().length > 0) {
+		console.error(oTaskRunnerReporter.getFindings());
+		throw new Error("Found entries to be migrated!");
+	}
+	return result;
 }

--- a/src/reporter/BaseReporter.ts
+++ b/src/reporter/BaseReporter.ts
@@ -1,0 +1,67 @@
+import * as ESTree from "estree";
+
+import {Finding, fromLoc, ReportContext, Reporter, ReportLevel} from "./Reporter";
+
+/**
+ * Represents a reporter base class which can:
+ * * handle findings
+ * * handle a context
+ */
+export abstract class BaseReporter implements Reporter {
+	findings: Finding[];
+	oReportContext: ReportContext;
+
+	protected constructor() {
+		this.findings = [];
+		this.oReportContext = {};
+	}
+
+	/**
+	 * get reported entries
+	 */
+	getFindings(): Finding[] {
+		return this.findings;
+	}
+
+	/**
+	 * Stores a finding
+	 * @param message the message
+	 * @param loc source code location
+	 */
+	storeFinding(message: string, loc?: ESTree.SourceLocation) {
+		this.findings.push({
+			fileName : this.oReportContext.fileName,
+			location : fromLoc(loc),
+			message,
+			taskName : this.oReportContext.taskName
+		});
+	}
+
+	/**
+	 * Set the context of the reporter
+	 * @param oReportContext
+	 */
+	setContext(oReportContext: ReportContext): void {
+		this.oReportContext = oReportContext;
+	}
+
+	/**
+	 * Retrieves the context of the reporter
+	 */
+	getContext(): ReportContext {
+		return this.oReportContext;
+	}
+
+	collect(sKey: string, sValue: string|number): void {
+	}
+
+	finalize(): Promise<{}> {
+		return undefined;
+	}
+
+	report(level: ReportLevel, msg: string, loc?: ESTree.SourceLocation): void {
+	}
+
+	reportCollected(level: ReportLevel): void {
+	}
+}

--- a/src/reporter/BaseReporter.ts
+++ b/src/reporter/BaseReporter.ts
@@ -52,16 +52,24 @@ export abstract class BaseReporter implements Reporter {
 		return this.oReportContext;
 	}
 
-	collect(sKey: string, sValue: string|number): void {
-	}
+	/**
+	 * @see Reporter#collect
+	 */
+	abstract collect(sKey: string, sValue: string|number): void;
 
-	finalize(): Promise<{}> {
-		return undefined;
-	}
+	/**
+	 * @see Reporter#finalize
+	 */
+	abstract finalize(): Promise<{}>;
 
-	report(level: ReportLevel, msg: string, loc?: ESTree.SourceLocation): void {
-	}
+	/**
+	 * @see Reporter#report
+	 */
+	abstract report(
+		level: ReportLevel, msg: string, loc?: ESTree.SourceLocation): void;
 
-	reportCollected(level: ReportLevel): void {
-	}
+	/**
+	 * @see Reporter#reportCollected
+	 */
+	abstract reportCollected(level: ReportLevel): void;
 }

--- a/src/reporter/ConsoleReporter.ts
+++ b/src/reporter/ConsoleReporter.ts
@@ -2,7 +2,7 @@
 
 import * as ESTree from "estree";
 
-import {CompareReportLevel, Finding, ReportContext, Reporter, ReportLevel} from "./Reporter";
+import {CompareReportLevel, Finding, fromLoc, ReportContext, Reporter, ReportLevel} from "./Reporter";
 
 export class ConsoleReporter implements Reporter {
 	sLevel: ReportLevel;
@@ -26,7 +26,7 @@ export class ConsoleReporter implements Reporter {
 	storeFinding(msg: string, loc?: ESTree.SourceLocation) {
 		this.findings.push({
 			filename : this.oReportContext.fileName,
-			loc,
+			location : fromLoc(loc),
 			msg,
 			taskName : this.oReportContext.taskName
 		});

--- a/src/reporter/ConsoleReporter.ts
+++ b/src/reporter/ConsoleReporter.ts
@@ -2,18 +2,19 @@
 
 import * as ESTree from "estree";
 
-import {CompareReportLevel, Finding, fromLoc, ReportContext, Reporter, ReportLevel} from "./Reporter";
+import {BaseReporter} from "./BaseReporter";
+import {CompareReportLevel, Finding, fromLoc, ReportLevel} from "./Reporter";
 
-export class ConsoleReporter implements Reporter {
+/**
+ * Represents a Reporter which logs to the console
+ */
+export class ConsoleReporter extends BaseReporter {
 	sLevel: ReportLevel;
 	oMap: Map<string, string[]|number> = new Map();
-	oReportContext: ReportContext;
-	findings: Finding[];
 
 	constructor(level: ReportLevel) {
+		super();
 		this.sLevel = level;
-		this.oReportContext = {};
-		this.findings = [];
 	}
 
 	/**
@@ -25,10 +26,10 @@ export class ConsoleReporter implements Reporter {
 
 	storeFinding(msg: string, loc?: ESTree.SourceLocation) {
 		this.findings.push({
-			filename : this.oReportContext.fileName,
+			fileName : this.getContext().fileName,
 			location : fromLoc(loc),
-			msg,
-			taskName : this.oReportContext.taskName
+			message : msg,
+			taskName : this.getContext().taskName
 		});
 	}
 
@@ -43,16 +44,16 @@ export class ConsoleReporter implements Reporter {
 		// Format rest and output
 		sMessage += "\x1b[36m%s\x1b[0m ";
 		aParams.push(level);
-		if (this.oReportContext.taskName) {
-			aParams.push(this.oReportContext.taskName);
+		if (this.getContext().taskName) {
+			aParams.push(this.getContext().taskName);
 			sMessage += "\x1b[35m%s\x1b[0m ";
 		}
-		if (this.oReportContext.logPrefix) {
-			aParams.push(this.oReportContext.logPrefix);
+		if (this.getContext().logPrefix) {
+			aParams.push(this.getContext().logPrefix);
 			sMessage += "\x1b[35m%s\x1b[0m ";
 		}
-		if (this.oReportContext.fileName) {
-			let sOutFileName = this.oReportContext.fileName;
+		if (this.getContext().fileName) {
+			let sOutFileName = this.getContext().fileName;
 			if (loc) {
 				let oLocation: ESTree.SourceLocation;
 				oLocation = loc as ESTree.SourceLocation;
@@ -117,7 +118,7 @@ export class ConsoleReporter implements Reporter {
 			return;
 		}
 		const sReporter =
-			this.oReportContext.logPrefix || this.oReportContext.taskName;
+			this.getContext().logPrefix || this.getContext().taskName;
 		this.setContext({ logPrefix : "", fileName : "" });
 		ConsoleReporter.log(level, "");
 		ConsoleReporter.log(
@@ -132,14 +133,6 @@ export class ConsoleReporter implements Reporter {
 			}
 		});
 		this.oMap.clear();
-	}
-
-	setContext(oReportContext: ReportContext): void {
-		this.oReportContext = oReportContext;
-	}
-
-	getContext(): ReportContext {
-		return this.oReportContext;
 	}
 
 	async finalize(): Promise<{}> {

--- a/src/reporter/ConsoleReporter.ts
+++ b/src/reporter/ConsoleReporter.ts
@@ -2,16 +2,34 @@
 
 import * as ESTree from "estree";
 
-import {CompareReportLevel, ReportContext, Reporter, ReportLevel} from "./Reporter";
+import {CompareReportLevel, Finding, ReportContext, Reporter, ReportLevel} from "./Reporter";
 
 export class ConsoleReporter implements Reporter {
 	sLevel: ReportLevel;
 	oMap: Map<string, string[]|number> = new Map();
 	oReportContext: ReportContext;
+	findings: Finding[];
 
 	constructor(level: ReportLevel) {
 		this.sLevel = level;
 		this.oReportContext = {};
+		this.findings = [];
+	}
+
+	/**
+	 * get reported entries
+	 */
+	getFindings(): Finding[] {
+		return this.findings;
+	}
+
+	storeFinding(msg: string, loc?: ESTree.SourceLocation) {
+		this.findings.push({
+			filename : this.oReportContext.fileName,
+			loc,
+			msg,
+			taskName : this.oReportContext.taskName
+		});
 	}
 
 	report(level: ReportLevel, msg: string, loc?: ESTree.SourceLocation) {

--- a/src/reporter/JSONReporter.ts
+++ b/src/reporter/JSONReporter.ts
@@ -1,6 +1,7 @@
 import * as ESTree from "estree";
 
-import {CompareReportLevel, Finding, fromLoc, ReportContext, Reporter, ReportLevel} from "./Reporter";
+import {BaseReporter} from "./BaseReporter";
+import {CompareReportLevel, ReportContext, ReportLevel} from "./Reporter";
 
 export interface JSONReporterResult {
 	reports: JSONReporterItem[];
@@ -18,36 +19,17 @@ export interface JSONReporterItem {
 	};
 }
 
-export class JSONReporter implements Reporter {
+export class JSONReporter extends BaseReporter {
 	sLevel: ReportLevel;
 	aItems: JSONReporterItem[];
 	sFileName: string;
-	oContext: ReportContext;
 	oMap: Map<string, string[]|number> = new Map();
-	findings: Finding[];
 
 	constructor(level: ReportLevel) {
+		super();
 		this.sLevel = level;
 		this.sFileName = "";
 		this.aItems = [];
-		this.oContext = {};
-		this.findings = [];
-	}
-
-	storeFinding(msg: string, loc?: ESTree.SourceLocation) {
-		this.findings.push({
-			filename : this.oContext.fileName,
-			location : fromLoc(loc),
-			msg,
-			taskName : this.oContext.taskName
-		});
-	}
-
-	/**
-	 * get reported entries
-	 */
-	getFindings(): Finding[] {
-		return this.findings;
 	}
 
 	report(level: ReportLevel, msg: string, locNode?: ESTree.SourceLocation) {
@@ -69,7 +51,7 @@ export class JSONReporter implements Reporter {
 			fileName : this.sFileName,
 			level,
 			codeReplacement : !!locNode,
-			context : this.oContext,
+			context : this.getContext(),
 			message : msg,
 			location : {
 				start : {
@@ -116,14 +98,6 @@ export class JSONReporter implements Reporter {
 			}
 		});
 		this.oMap.clear();
-	}
-
-	setContext(oContext: ReportContext): void {
-		this.oContext = oContext;
-	}
-
-	getContext(): ReportContext {
-		return this.oContext;
 	}
 
 	async finalize(): Promise<JSONReporterResult> {

--- a/src/reporter/JSONReporter.ts
+++ b/src/reporter/JSONReporter.ts
@@ -1,6 +1,6 @@
 import * as ESTree from "estree";
 
-import {CompareReportLevel, Finding, ReportContext, Reporter, ReportLevel} from "./Reporter";
+import {CompareReportLevel, Finding, fromLoc, ReportContext, Reporter, ReportLevel} from "./Reporter";
 
 export interface JSONReporterResult {
 	reports: JSONReporterItem[];
@@ -37,9 +37,7 @@ export class JSONReporter implements Reporter {
 	storeFinding(msg: string, loc?: ESTree.SourceLocation) {
 		this.findings.push({
 			filename : this.oContext.fileName,
-			loc : {
-				start: loc.start.column
-			},
+			location : fromLoc(loc),
 			msg,
 			taskName : this.oContext.taskName
 		});

--- a/src/reporter/JSONReporter.ts
+++ b/src/reporter/JSONReporter.ts
@@ -1,6 +1,6 @@
 import * as ESTree from "estree";
 
-import {CompareReportLevel, ReportContext, Reporter, ReportLevel} from "./Reporter";
+import {CompareReportLevel, Finding, ReportContext, Reporter, ReportLevel} from "./Reporter";
 
 export interface JSONReporterResult {
 	reports: JSONReporterItem[];
@@ -24,12 +24,32 @@ export class JSONReporter implements Reporter {
 	sFileName: string;
 	oContext: ReportContext;
 	oMap: Map<string, string[]|number> = new Map();
+	findings: Finding[];
 
 	constructor(level: ReportLevel) {
 		this.sLevel = level;
 		this.sFileName = "";
 		this.aItems = [];
 		this.oContext = {};
+		this.findings = [];
+	}
+
+	storeFinding(msg: string, loc?: ESTree.SourceLocation) {
+		this.findings.push({
+			filename : this.oContext.fileName,
+			loc : {
+				start: loc.start.column
+			},
+			msg,
+			taskName : this.oContext.taskName
+		});
+	}
+
+	/**
+	 * get reported entries
+	 */
+	getFindings(): Finding[] {
+		return this.findings;
 	}
 
 	report(level: ReportLevel, msg: string, locNode?: ESTree.SourceLocation) {

--- a/src/reporter/MetaConsoleReporter.ts
+++ b/src/reporter/MetaConsoleReporter.ts
@@ -1,12 +1,16 @@
+import * as ESTree from "estree";
+
 import {ConsoleReporter} from "./ConsoleReporter";
-import {Reporter, ReportLevel} from "./Reporter";
+import {Finding, Reporter, ReportLevel} from "./Reporter";
 
 export class MetaConsoleReporter extends ConsoleReporter {
 	oReporters: { [index: string]: Reporter };
+	findings: Finding[];
 
 	constructor(level: ReportLevel) {
 		super(level);
 		this.oReporters = {};
+		this.findings = [];
 	}
 
 	createReporter(level: ReportLevel): Reporter {
@@ -30,6 +34,21 @@ export class MetaConsoleReporter extends ConsoleReporter {
 	getReporters(): Reporter[] {
 		return Object.keys(this.oReporters)
 			.map((sKey) => this.oReporters[sKey]);
+	}
+
+	storeFinding(msg: string, loc?: ESTree.SourceLocation) {
+		this.findings.push({ filename : "meta", taskName : "meta", loc, msg });
+	}
+
+	/**
+	 * get reported entries
+	 */
+	getFindings(): Finding[] {
+		let results = this.findings.slice();
+		this.getReporters().forEach((oReporter) => {
+			results = results.concat(oReporter.getFindings());
+		});
+		return results;
 	}
 
 	reportCollected(level: ReportLevel) {

--- a/src/reporter/MetaConsoleReporter.ts
+++ b/src/reporter/MetaConsoleReporter.ts
@@ -3,6 +3,9 @@ import * as ESTree from "estree";
 import {ConsoleReporter} from "./ConsoleReporter";
 import {Finding, fromLoc, Reporter, ReportLevel} from "./Reporter";
 
+/**
+ * Reporter which contains multiple ConsoleReporters
+ */
 export class MetaConsoleReporter extends ConsoleReporter {
 	oReporters: { [index: string]: Reporter };
 	findings: Finding[];
@@ -36,17 +39,12 @@ export class MetaConsoleReporter extends ConsoleReporter {
 			.map((sKey) => this.oReporters[sKey]);
 	}
 
-	storeFinding(msg: string, loc?: ESTree.SourceLocation) {
-		this.findings.push({
-			filename : "meta",
-			taskName : "meta",
-			location : fromLoc(loc),
-			msg
-		});
+	storeFinding(message: string, loc?: ESTree.SourceLocation) {
+		// NOOP since this is only handling a set of ConsoleReporters
 	}
 
 	/**
-	 * get reported entries
+	 * get reported entries from all its nested reporters
 	 */
 	getFindings(): Finding[] {
 		let results = this.findings.slice();

--- a/src/reporter/MetaConsoleReporter.ts
+++ b/src/reporter/MetaConsoleReporter.ts
@@ -1,7 +1,7 @@
 import * as ESTree from "estree";
 
 import {ConsoleReporter} from "./ConsoleReporter";
-import {Finding, Reporter, ReportLevel} from "./Reporter";
+import {Finding, fromLoc, Reporter, ReportLevel} from "./Reporter";
 
 export class MetaConsoleReporter extends ConsoleReporter {
 	oReporters: { [index: string]: Reporter };
@@ -37,7 +37,12 @@ export class MetaConsoleReporter extends ConsoleReporter {
 	}
 
 	storeFinding(msg: string, loc?: ESTree.SourceLocation) {
-		this.findings.push({ filename : "meta", taskName : "meta", loc, msg });
+		this.findings.push({
+			filename : "meta",
+			taskName : "meta",
+			location : fromLoc(loc),
+			msg
+		});
 	}
 
 	/**

--- a/src/reporter/Reporter.ts
+++ b/src/reporter/Reporter.ts
@@ -37,6 +37,12 @@ export interface ReportContext {
 	logPrefix?: string;
 }
 
+/**
+ * Transforms an ESTree.SourceLocation into a FindingLocation.
+ * Because the ESTree.SourceLocation contains too many properties while
+ * FindingLocation only contains the needed properties.
+ * @param loc
+ */
 export function fromLoc(loc: ESTree.SourceLocation): FindingLocation {
 	if (!loc) {
 		return { endLine : 0, endColumn : 0, startLine : 0, startColumn : 0 };
@@ -49,6 +55,9 @@ export function fromLoc(loc: ESTree.SourceLocation): FindingLocation {
 	};
 }
 
+/**
+ * Source code location
+ */
 export interface FindingLocation {
 	endLine: number;
 	endColumn: number;
@@ -56,10 +65,13 @@ export interface FindingLocation {
 	startColumn: number;
 }
 
+/**
+ * Represents a Finding of code to replace
+ */
 export interface Finding {
-	msg: string;
+	message: string;
 	location: FindingLocation;
-	filename: string;
+	fileName: string;
 	taskName: string;
 }
 

--- a/src/reporter/Reporter.ts
+++ b/src/reporter/Reporter.ts
@@ -38,6 +38,9 @@ export interface ReportContext {
 }
 
 export function fromLoc(loc: ESTree.SourceLocation): FindingLocation {
+	if (!loc) {
+		return { endLine : 0, endColumn : 0, startLine : 0, startColumn : 0 };
+	}
 	return {
 		endLine : loc.end.line,
 		endColumn : loc.end.column,

--- a/src/reporter/Reporter.ts
+++ b/src/reporter/Reporter.ts
@@ -37,6 +37,13 @@ export interface ReportContext {
 	logPrefix?: string;
 }
 
+export interface Finding {
+	msg: string;
+	loc: {start:number, end:number};
+	filename: string;
+	taskName: string;
+}
+
 /**
  * Used by migration modules to report information or errors.
  *
@@ -51,6 +58,17 @@ export interface Reporter {
 	 */
 	report(level: ReportLevel, msg: string, loc?: ESTree.SourceLocation): void;
 
+	/**
+	 * persists the finding
+	 * @param msg
+	 * @param loc
+	 */
+	storeFinding(msg: string, loc?: ESTree.SourceLocation);
+
+	/**
+	 * get reported entries
+	 */
+	getFindings(): Finding[];
 	/**
 	 * stores report relevant information
 	 * @param {string} sKey

--- a/src/reporter/Reporter.ts
+++ b/src/reporter/Reporter.ts
@@ -37,9 +37,25 @@ export interface ReportContext {
 	logPrefix?: string;
 }
 
+export function fromLoc(loc: ESTree.SourceLocation): FindingLocation {
+	return {
+		endLine : loc.end.line,
+		endColumn : loc.end.column,
+		startLine : loc.start.line,
+		startColumn : loc.start.column
+	};
+}
+
+export interface FindingLocation {
+	endLine: number;
+	endColumn: number;
+	startLine: number;
+	startColumn: number;
+}
+
 export interface Finding {
 	msg: string;
-	loc: {start:number, end:number};
+	location: FindingLocation;
 	filename: string;
 	taskName: string;
 }

--- a/src/tasks/addMissingDependencies.ts
+++ b/src/tasks/addMissingDependencies.ts
@@ -351,7 +351,6 @@ async function migrate(args: Mod.MigrateArguments): Promise<boolean> {
 				args.reporter.collect(
 					oNodePath.parentPath.value.property.name, 1);
 			}
-
 			bFileModified = true;
 		} catch (e) {
 			args.reporter.report(

--- a/src/tasks/addMissingDependencies.ts
+++ b/src/tasks/addMissingDependencies.ts
@@ -54,7 +54,7 @@ function mapToFound(oPath: NodePath, oFound: FoundReplacement): FoundCall {
 }
 
 const visit = function(
-	analysis: Analysis, oModuleTree: {}, finders: { [p: string]: Finder },
+	analysis: Analysis, oModuleTree: {}, finders: { [name: string]: Finder },
 	reporter: Reporter, defineCall: SapUiDefineCall) {
 	// @ts-ignore
 	return function(oPath) {
@@ -113,13 +113,21 @@ function findCallsToReplace(
 	return analysis;
 }
 
-
+/**
+ * Uses the finders to check if the given node contains valid findings.
+ * Returns the findings.
+ * @param oNode
+ * @param oNodePath
+ * @param oModuleTree
+ * @param finder
+ * @param defineCall
+ */
 function isFoundInConfig(
 	oNode: ESTree.Node, oNodePath: NodePath, oModuleTree: {
-		[p: string]:
-			{ [p: string]: { finder: string; newModulePath : string } }
+		[index: string]:
+			{ [index: string]: { finder: string; newModulePath : string } }
 	},
-	finder: { [p: string]: Finder },
+	finder: { [name: string]: Finder },
 	defineCall: SapUiDefineCall): FoundReplacement[] {
 	const aCalls = [];
 	for (const sModule in oModuleTree) {

--- a/src/tasks/addRenderers.ts
+++ b/src/tasks/addRenderers.ts
@@ -213,10 +213,7 @@ async function analyse(args: Mod.AnalyseArguments):
 
 	if (rendererExists && !embeddedRenderer.rendererDefined &&
 		!bRendererImportDefined) {
-		args.reporter.report(
-			Mod.ReportLevel.ERROR,
-			"detected missing dependency to Renderer module",
-			defineCall.node.callee.loc);
+		args.reporter.collect("missingRenderer", 1);
 		args.reporter.storeFinding(
 			"Missing Renderer", defineCall.node.callee.loc);
 		return {
@@ -239,7 +236,7 @@ async function migrate(args: Mod.MigrateArguments): Promise<boolean> {
 		const rendererModuleName = getRendererParameterName(args.file);
 		if (result.defineCall.getImportByParamName(rendererModuleName)) {
 			args.reporter.report(
-				ReportLevel.ERROR,
+				ReportLevel.WARNING,
 				"Renderer already defined for " + args.file.getFileName() +
 					". Renderer param name: " + rendererModuleName);
 			return false;

--- a/src/tasks/addRenderers.ts
+++ b/src/tasks/addRenderers.ts
@@ -217,6 +217,8 @@ async function analyse(args: Mod.AnalyseArguments):
 			Mod.ReportLevel.ERROR,
 			"detected missing dependency to Renderer module",
 			defineCall.node.callee.loc);
+		args.reporter.storeFinding(
+			"Missing Renderer", defineCall.node.callee.loc);
 		return {
 			defineCall,
 			shouldAddRenderer : true,

--- a/src/tasks/helpers/finders/AssignReplacementFinder.ts
+++ b/src/tasks/helpers/finders/AssignReplacementFinder.ts
@@ -4,6 +4,7 @@ import * as recast from "recast";
 import {NodePath} from "ui5-migration";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 
 /**
@@ -16,7 +17,9 @@ import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
  * </code>
  */
 class AssignReplacementFinder implements Finder {
-	find(node: ESTree.Node, config: {}, sConfigName: string): FinderResult {
+	find(
+		node: ESTree.Node, config: {}, sConfigName: string,
+		defineCall: SapUiDefineCall): FinderResult {
 		if (node.type === Syntax.CallExpression &&
 			node.callee.type === Syntax.MemberExpression &&
 			node.callee.object.type === Syntax.MemberExpression &&

--- a/src/tasks/helpers/finders/CallWithArgumentFinder.ts
+++ b/src/tasks/helpers/finders/CallWithArgumentFinder.ts
@@ -5,6 +5,7 @@ import * as recast from "recast";
 import {NodePath} from "ui5-migration";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 
 /**
@@ -19,7 +20,7 @@ import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
 class CallWithArgumentFinder implements Finder {
 	find(
 		node: ESTree.Node, config: { finderIncludesName: string },
-		sConfigName: string): FinderResult {
+		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
 		if (node.type === Syntax.CallExpression) {
 			if (node.arguments.length > 0 &&
 				node.arguments[0].type === Syntax.Literal) {

--- a/src/tasks/helpers/finders/CallWithArgumentFinderWithDependencyCheck.ts
+++ b/src/tasks/helpers/finders/CallWithArgumentFinderWithDependencyCheck.ts
@@ -1,0 +1,28 @@
+import * as ESTree from "estree";
+const callWithArgumentFinder = require("./CallWithArgumentFinder");
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
+
+import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+
+
+class CallWithArgumentFinderWithDependencyCheck implements Finder {
+	find(
+		node: ESTree.Node, config: { newModulePath: string },
+		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
+		const result =
+			callWithArgumentFinder.find(node, config, sConfigName, defineCall);
+		if (result === EMPTY_FINDER_RESULT) {
+			return EMPTY_FINDER_RESULT;
+		} else if (
+			config.newModulePath &&
+			defineCall.getNodeOfImport(config.newModulePath)) {
+			return EMPTY_FINDER_RESULT;
+		}
+		return result;
+	}
+}
+
+/**
+ *
+ */
+module.exports = new CallWithArgumentFinderWithDependencyCheck();

--- a/src/tasks/helpers/finders/CallWithArgumentFinderWithDependencyCheck.ts
+++ b/src/tasks/helpers/finders/CallWithArgumentFinderWithDependencyCheck.ts
@@ -4,18 +4,20 @@ import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
 
-
+/**
+ * @see CallWithArgumentFinder but checks the dependencies if the newModulePath is already in the config
+ */
 class CallWithArgumentFinderWithDependencyCheck implements Finder {
 	find(
 		node: ESTree.Node, config: { newModulePath: string },
 		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
 		const result =
 			callWithArgumentFinder.find(node, config, sConfigName, defineCall);
-		if (result === EMPTY_FINDER_RESULT) {
-			return EMPTY_FINDER_RESULT;
-		} else if (
-			config.newModulePath &&
-			defineCall.getNodeOfImport(config.newModulePath)) {
+		// if the result is already empty or the dependency is already present
+		// nothing is found
+		if (result === EMPTY_FINDER_RESULT ||
+			(config.newModulePath &&
+			 defineCall.getNodeOfImport(config.newModulePath))) {
 			return EMPTY_FINDER_RESULT;
 		}
 		return result;

--- a/src/tasks/helpers/finders/FunctionExtensionFinder.ts
+++ b/src/tasks/helpers/finders/FunctionExtensionFinder.ts
@@ -4,10 +4,13 @@ import * as recast from "recast";
 import {NodePath} from "ui5-migration";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 
 class FunctionExtensionFinder implements Finder {
-	find(node: ESTree.Node, config: {}, sConfigName: string): FinderResult {
+	find(
+		node: ESTree.Node, config: {}, sConfigName: string,
+		defineCall: SapUiDefineCall): FinderResult {
 		const oObject = sConfigName.split(".");
 		if (node.type === Syntax.CallExpression) {
 			const callee = node.callee;

--- a/src/tasks/helpers/finders/FunctionExtensionFinderWithDependencyCheck.ts
+++ b/src/tasks/helpers/finders/FunctionExtensionFinderWithDependencyCheck.ts
@@ -4,18 +4,20 @@ import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
 
-
+/**
+ * @see FunctionExtensionFinder but checks the dependencies if the newModulePath is already in the config
+ */
 class FunctionExtensionFinderWithDependencyCheck implements Finder {
 	find(
 		node: ESTree.Node, config: { newModulePath: string },
 		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
 		const result =
 			functionExtensionFinder.find(node, config, sConfigName, defineCall);
-		if (result === EMPTY_FINDER_RESULT) {
-			return EMPTY_FINDER_RESULT;
-		} else if (
-			config.newModulePath &&
-			defineCall.getNodeOfImport(config.newModulePath)) {
+		// if the result is already empty or the dependency is already present
+		// nothing is found
+		if (result === EMPTY_FINDER_RESULT ||
+			(config.newModulePath &&
+			 defineCall.getNodeOfImport(config.newModulePath))) {
 			return EMPTY_FINDER_RESULT;
 		}
 		return result;

--- a/src/tasks/helpers/finders/FunctionExtensionFinderWithDependencyCheck.ts
+++ b/src/tasks/helpers/finders/FunctionExtensionFinderWithDependencyCheck.ts
@@ -1,0 +1,28 @@
+import * as ESTree from "estree";
+const functionExtensionFinder = require("./FunctionExtensionFinder");
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
+
+import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+
+
+class FunctionExtensionFinderWithDependencyCheck implements Finder {
+	find(
+		node: ESTree.Node, config: { newModulePath: string },
+		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
+		const result =
+			functionExtensionFinder.find(node, config, sConfigName, defineCall);
+		if (result === EMPTY_FINDER_RESULT) {
+			return EMPTY_FINDER_RESULT;
+		} else if (
+			config.newModulePath &&
+			defineCall.getNodeOfImport(config.newModulePath)) {
+			return EMPTY_FINDER_RESULT;
+		}
+		return result;
+	}
+}
+
+/**
+ *
+ */
+module.exports = new FunctionExtensionFinderWithDependencyCheck();

--- a/src/tasks/helpers/finders/JQueryDOMVariableNameFinder.ts
+++ b/src/tasks/helpers/finders/JQueryDOMVariableNameFinder.ts
@@ -4,6 +4,7 @@ import * as recast from "recast";
 import {NodePath} from "ui5-migration";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 
 /**
@@ -18,7 +19,7 @@ import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
 class JQueryDOMVariableNameFinder implements Finder {
 	find(
 		node: ESTree.Node, config: { variableNameToFind: string },
-		sConfigName: string): FinderResult {
+		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
 		const sNameToFind = config.variableNameToFind;
 
 

--- a/src/tasks/helpers/finders/JQueryEventExtensionFinder.ts
+++ b/src/tasks/helpers/finders/JQueryEventExtensionFinder.ts
@@ -4,12 +4,13 @@ import * as recast from "recast";
 import {NodePath} from "ui5-migration";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 
 class JQueryEventExtensionFinder implements Finder {
 	find(
 		node: ESTree.Node, config: { finderIncludesName: string },
-		sConfigName: string): FinderResult {
+		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
 		const oObject = sConfigName.split(".");
 		if (node.type === Syntax.MemberExpression) {
 			if (node.object.type === Syntax.Identifier &&

--- a/src/tasks/helpers/finders/JQueryFunctionExtensionFinder.ts
+++ b/src/tasks/helpers/finders/JQueryFunctionExtensionFinder.ts
@@ -4,6 +4,7 @@ import * as recast from "recast";
 import {NodePath} from "ui5-migration";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 
 function includesJQuery(node) {
@@ -13,7 +14,9 @@ function includesJQuery(node) {
 
 
 class FunctionExtensionFinder implements Finder {
-	find(node: ESTree.Node, config: {}, sConfigName: string): FinderResult {
+	find(
+		node: ESTree.Node, config: {}, sConfigName: string,
+		defineCall: SapUiDefineCall): FinderResult {
 		const oObject = sConfigName.split(".");
 		if (oObject.length !== 2) {
 			return undefined;

--- a/src/tasks/helpers/finders/JQueryFunctionExtensionFinderWithDependencyCheck.ts
+++ b/src/tasks/helpers/finders/JQueryFunctionExtensionFinderWithDependencyCheck.ts
@@ -1,0 +1,29 @@
+import * as ESTree from "estree";
+const jQueryFunctionExtensionFinder =
+	require("./JQueryFunctionExtensionFinder");
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
+
+import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+
+
+class JQueryFunctionExtensionFinderWithDependencyCheck implements Finder {
+	find(
+		node: ESTree.Node, config: { newModulePath: string },
+		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
+		const result = jQueryFunctionExtensionFinder.find(
+			node, config, sConfigName, defineCall);
+		if (result === EMPTY_FINDER_RESULT) {
+			return EMPTY_FINDER_RESULT;
+		} else if (
+			config.newModulePath &&
+			defineCall.getNodeOfImport(config.newModulePath)) {
+			return EMPTY_FINDER_RESULT;
+		}
+		return result;
+	}
+}
+
+/**
+ *
+ */
+module.exports = new JQueryFunctionExtensionFinderWithDependencyCheck();

--- a/src/tasks/helpers/finders/JQueryFunctionExtensionFinderWithDependencyCheck.ts
+++ b/src/tasks/helpers/finders/JQueryFunctionExtensionFinderWithDependencyCheck.ts
@@ -5,18 +5,20 @@ import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
 
-
+/**
+ * @see JQueryFunctionExtensionFinder but checks the dependencies if the newModulePath is already in the config
+ */
 class JQueryFunctionExtensionFinderWithDependencyCheck implements Finder {
 	find(
 		node: ESTree.Node, config: { newModulePath: string },
 		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
 		const result = jQueryFunctionExtensionFinder.find(
 			node, config, sConfigName, defineCall);
-		if (result === EMPTY_FINDER_RESULT) {
-			return EMPTY_FINDER_RESULT;
-		} else if (
-			config.newModulePath &&
-			defineCall.getNodeOfImport(config.newModulePath)) {
+		// if the result is already empty or the dependency is already present
+		// nothing is found
+		if (result === EMPTY_FINDER_RESULT ||
+			(config.newModulePath &&
+			 defineCall.getNodeOfImport(config.newModulePath))) {
 			return EMPTY_FINDER_RESULT;
 		}
 		return result;

--- a/src/tasks/helpers/finders/JQuerySapCallFinder.ts
+++ b/src/tasks/helpers/finders/JQuerySapCallFinder.ts
@@ -5,6 +5,7 @@ import * as recast from "recast";
 import {NodePath} from "ui5-migration";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 
 
@@ -18,7 +19,9 @@ import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
  * </code>
  */
 class JQuerySapFunctionFinder implements Finder {
-	find(node: ESTree.Node, config: {}, sConfigName: string): FinderResult {
+	find(
+		node: ESTree.Node, config: {}, sConfigName: string,
+		defineCall: SapUiDefineCall): FinderResult {
 		if (node.type === Syntax.MemberExpression) {
 			if (node.object.type === Syntax.Identifier &&
 				(node.object.name === "jQuery" || node.object.name === "$") &&

--- a/src/tasks/helpers/finders/JQuerySapExtendFinder.ts
+++ b/src/tasks/helpers/finders/JQuerySapExtendFinder.ts
@@ -5,6 +5,7 @@ import * as recast from "recast";
 import {NodePath} from "ui5-migration";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 
 /**
@@ -17,7 +18,9 @@ import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
  * </code>
  */
 class JQuerySapExtendFinder implements Finder {
-	find(node: ESTree.Node, config: {}, sConfigName: string): FinderResult {
+	find(
+		node: ESTree.Node, config: {}, sConfigName: string,
+		defineCall: SapUiDefineCall): FinderResult {
 		if (node.type === Syntax.CallExpression &&
 			node.callee.type === Syntax.MemberExpression &&
 			node.callee.object.type === Syntax.MemberExpression &&

--- a/src/tasks/helpers/finders/JQuerySapFunctionFinder.ts
+++ b/src/tasks/helpers/finders/JQuerySapFunctionFinder.ts
@@ -5,6 +5,7 @@ import * as recast from "recast";
 import {NodePath} from "ui5-migration";
 
 import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
 
 
 /**
@@ -48,7 +49,7 @@ const fnNestedMember = function(node: ESTree.Node, aList: string[]): boolean {
 class JQuerySapFunctionFinder implements Finder {
 	find(
 		node: ESTree.Node, config: { finderIncludesName: string },
-		sConfigName: string): FinderResult {
+		sConfigName: string, defineCall: SapUiDefineCall): FinderResult {
 		const aObject = sConfigName.split(".");  // jQuery.sap.extend
 
 

--- a/src/tasks/replaceGlobals.ts
+++ b/src/tasks/replaceGlobals.ts
@@ -316,6 +316,10 @@ async function analyse(args: Mod.AnalyseArguments): Promise<{}> {
 		}
 	}
 	const aCallsToReplace = findCallsToReplace(ast, oModuleTree, visitor);
+	aCallsToReplace.forEach((oCallToReplace) => {
+		args.reporter.storeFinding(
+			"found deprecated global", oCallToReplace.value.loc);
+	});
 	args.reporter.collect("callsToReplace", aCallsToReplace.length);
 
 	const mOldImports = {};

--- a/src/tasks/replaceGlobals.ts
+++ b/src/tasks/replaceGlobals.ts
@@ -96,11 +96,13 @@ function isCalleeMatchingModulesToReplace(
 	}
 
 	let oCurObject = oModuleTree;
+	const aParts = [];
 	for (const memberExprPart of memberExprParts) {
 		if (oCurObject.hasOwnProperty(memberExprPart)) {
+			aParts.push(memberExprPart);
 			oCurObject = oCurObject[memberExprPart];
 		} else {
-			return "*" in oCurObject ? memberExprParts.join(".") : undefined;
+			return "*" in oCurObject ? aParts.concat("*").join(".") : undefined;
 		}
 	}
 	return memberExprParts.join(".");
@@ -165,6 +167,11 @@ function wouldReplaceCall(
 	const callToReplaceInConfig = [
 		configEntry.newVariableName, configEntry.functionName
 	].filter(Boolean).join(".");
+
+	// special module LEAVE never triggers a replacement
+	if (configEntry.replacer && configEntry.replacer === "LEAVE") {
+		return false;
+	}
 
 	// already present and would replace it with the same
 	// e.g. "jQuery.get": {

--- a/src/util/AmdCleanerUtil.ts
+++ b/src/util/AmdCleanerUtil.ts
@@ -197,6 +197,8 @@ function replaceSelfCalls(
 			}
 			declareResult.path.prune();
 		} else {
+			reporter.storeFinding(
+				"remove declare statement", declareResult.path.loc);
 			oAnalysisResult["remove-path"] =
 				oAnalysisResult["remove-path"] || [];
 			oAnalysisResult["remove-path"].push("jQuery.sap.declare");
@@ -380,6 +382,8 @@ function visitCode(
 						path.prune();
 						bFileWasModified = true;
 					} else {
+						reporter.storeFinding(
+							"found jQuery.sap.require", path.loc);
 						oAnalysisResult["remove-path"] =
 							oAnalysisResult["remove-path"] || [];
 						oAnalysisResult["remove-path"].push(
@@ -459,6 +463,8 @@ function visitCode(
 							bFileWasModified = bFileWasModified ||
 								addDependencyResult.modified;
 						} else {
+							reporter.storeFinding(
+								"add dependency", path.value.loc);
 							oAnalysisResult["addDependency"] =
 								oAnalysisResult["addDependency"] || [];
 
@@ -501,6 +507,8 @@ function visitCode(
 										Mod.ReportLevel.DEBUG, "Add shortcut",
 										path.value.loc);
 								} else {
+									reporter.storeFinding(
+										"add shortcut", path.value.loc);
 									oAnalysisResult["addShortcut"] =
 										oAnalysisResult["addShortcut"] || [];
 
@@ -587,6 +595,8 @@ function visitCode(
 									"Replace occurrence of " + replacementStr,
 									oLoc);
 							} else {
+								reporter.storeFinding(
+									"replace", path.value.loc);
 								oAnalysisResult["replace"] =
 									oAnalysisResult["replace"] || [];
 
@@ -623,6 +633,7 @@ function visitCode(
 							Mod.ReportLevel.DEBUG, "Add dependency",
 							path.value.loc);
 					} else {
+						reporter.storeFinding("add dependency", path.value.loc);
 						oAnalysisResult["addDependency"] =
 							oAnalysisResult["addDependency"] || [];
 
@@ -658,6 +669,7 @@ function visitCode(
 						path.replace(builders.identifier(localRef));
 						bFileWasModified = true;
 					} else {
+						reporter.storeFinding("replace", path.value.loc);
 						oAnalysisResult["replace"] =
 							oAnalysisResult["replace"] || [];
 
@@ -692,6 +704,7 @@ function visitCode(
 							Mod.ReportLevel.DEBUG, "Parent replacement",
 							path.value.loc);
 					} else {
+						reporter.storeFinding("replace parent", path.value.loc);
 						oAnalysisResult["parentReplace"] =
 							oAnalysisResult["parentReplace"] || [];
 
@@ -831,6 +844,8 @@ module.exports = {
 					Mod.ReportLevel.DEBUG, "Create empty define call",
 					(ast as ESTree.Program).loc);
 			} else {
+				reporter.storeFinding(
+					"Create define call", (ast as ESTree.Program).loc);
 				oAnalysisResult["body"] = oAnalysisResult["body"] || [];
 
 				oAnalysisResult["body"].push({
@@ -888,6 +903,8 @@ module.exports = {
 						(ast as ESTree.Program).loc);
 				}
 			} else {
+				reporter.storeFinding(
+					"Convert export", (ast as ESTree.Program).loc);
 				oAnalysisResult["convertExport"] =
 					oAnalysisResult["convertExport"] || [];
 
@@ -976,6 +993,8 @@ module.exports = {
 										sVariableName,
 									oLastStatement.loc);
 							} else {
+								reporter.storeFinding(
+									"return statement", oLastStatement.loc);
 								oAnalysisResult["returnStatement"] =
 									oAnalysisResult["returnStatement"] || [];
 
@@ -992,6 +1011,9 @@ module.exports = {
 									"Added true for global export",
 									oLastStatement.loc);
 							} else {
+								reporter.storeFinding(
+									"Add true for global export",
+									oLastStatement.loc);
 								oAnalysisResult["globalExport"] =
 									oAnalysisResult["globalExport"] || [];
 
@@ -1868,6 +1890,7 @@ function removeUnusedDependencies(
 				reporter.report(
 					Mod.ReportLevel.DEBUG, "Remove dependency", ast.loc);
 			} else {
+				reporter.storeFinding("remove dependency", ast.loc);
 				oAnalysisResult["removeDependency"] =
 					oAnalysisResult["removeDependency"] || [];
 				oAnalysisResult["removeDependency"].push(

--- a/src/util/AmdCleanerUtil.ts
+++ b/src/util/AmdCleanerUtil.ts
@@ -198,7 +198,7 @@ function replaceSelfCalls(
 			declareResult.path.prune();
 		} else {
 			reporter.storeFinding(
-				"remove declare statement", declareResult.path.loc);
+				"remove declare statement", declareResult.path.value.loc);
 			oAnalysisResult["remove-path"] =
 				oAnalysisResult["remove-path"] || [];
 			oAnalysisResult["remove-path"].push("jQuery.sap.declare");

--- a/src/util/SapUiDefineCall.ts
+++ b/src/util/SapUiDefineCall.ts
@@ -116,7 +116,7 @@ export class SapUiDefineCall {
 			this.dependencyInsertionIdx = this.dependencyArray.elements.length;
 		}
 
-		if (args[i].type === Syntax.FunctionExpression) {
+		if (args[i] && args[i].type === Syntax.FunctionExpression) {
 			this.factory = args[i++] as ESTree.FunctionExpression;
 			const params = this.factory.params;
 			this.paramNames = params.map(function(param) {

--- a/src/util/SapUiDefineCall.ts
+++ b/src/util/SapUiDefineCall.ts
@@ -92,6 +92,11 @@ export class SapUiDefineCall {
 		this.name = moduleName;
 		this.reporter = reporter;
 		this.dependencyArray = null;
+
+		/**
+		 * can be checked if the to determine if the sap.ui.define call is
+		 * usable for the tasks
+		 */
 		this.factory = null;
 
 		this.bExportsNode = null;
@@ -116,6 +121,8 @@ export class SapUiDefineCall {
 			this.dependencyInsertionIdx = this.dependencyArray.elements.length;
 		}
 
+		// There are sap.ui.defines which do not contain a function.
+		// These should not fail here. The #factory property is then null.
 		if (args[i] && args[i].type === Syntax.FunctionExpression) {
 			this.factory = args[i++] as ESTree.FunctionExpression;
 			const params = this.factory.params;

--- a/src/util/TypeDependencyUtil.ts
+++ b/src/util/TypeDependencyUtil.ts
@@ -125,6 +125,9 @@ export async function fixTypeDependency(
 						reporter.collect("Found missing module", 1);
 						reporter.collect(
 							"Added library dependency: " + oSymbol.module, 1);
+						reporter.storeFinding(
+							"Found missing module",
+							(depObj as ESTree.Literal).loc);
 						if (modify) {
 							// get param name of the library
 							let localRef =

--- a/test/util/testUtils.ts
+++ b/test/util/testUtils.ts
@@ -1,10 +1,10 @@
 import * as ESTree from "estree";
-import {Node} from "estree";
+import {Node, SourceLocation} from "estree";
 
 import * as Mod from "../../src/Migration";
 import {AnalyseArguments, MigrateArguments, ReportLevel} from "../../src/Migration";
 import {MetaConsoleReporter} from "../../src/reporter/MetaConsoleReporter";
-import {ReportContext, Reporter} from "../../src/reporter/Reporter";
+import {Finding, ReportContext, Reporter} from "../../src/reporter/Reporter";
 import {MigrationTask} from "../../src/taskRunner";
 import {FileInfo} from "../../src/util/FileInfo";
 
@@ -76,6 +76,13 @@ export class CustomReporter implements Reporter {
 
 	getReports() {
 		return this.reports;
+	}
+
+	getFindings(): Finding[] {
+		return [];
+	}
+
+	storeFinding(msg: string, loc?: SourceLocation) {
 	}
 }
 

--- a/test/util/testUtils.ts
+++ b/test/util/testUtils.ts
@@ -3,6 +3,7 @@ import {Node, SourceLocation} from "estree";
 
 import * as Mod from "../../src/Migration";
 import {AnalyseArguments, MigrateArguments, ReportLevel} from "../../src/Migration";
+import {BaseReporter} from "../../src/reporter/BaseReporter";
 import {MetaConsoleReporter} from "../../src/reporter/MetaConsoleReporter";
 import {Finding, ReportContext, Reporter} from "../../src/reporter/Reporter";
 import {MigrationTask} from "../../src/taskRunner";
@@ -38,11 +39,12 @@ export class CustomMetaReporter extends MetaConsoleReporter {
 	}
 }
 
-export class CustomReporter implements Reporter {
+export class CustomReporter extends BaseReporter {
 	private reports: string[];
 	private level: string;
 
 	constructor(reports = [], level = "debug") {
+		super();
 		this.reports = reports;
 		this.level = level;
 	}
@@ -67,22 +69,8 @@ export class CustomReporter implements Reporter {
 		return Promise.resolve({});
 	}
 
-	setContext(oContext: ReportContext): void {
-	}
-
-	getContext(): ReportContext {
-		return {};
-	}
-
 	getReports() {
 		return this.reports;
-	}
-
-	getFindings(): Finding[] {
-		return [];
-	}
-
-	storeFinding(msg: string, loc?: SourceLocation) {
 	}
 }
 
@@ -91,7 +79,9 @@ export class CustomFileInfo implements Mod.FileInfo {
 	private name: string;
 	private ast: ESTree.Node;
 	private namespace: string;
+	private path: string;
 	constructor(path: string, namespace?: string) {
+		this.path = path;
 		this.name = path.replace(/\.js$/, "");
 		this.sourceCode = fs.readFileSync(path, "utf8");
 		this.ast = recast.parse(this.sourceCode).program;
@@ -115,7 +105,7 @@ export class CustomFileInfo implements Mod.FileInfo {
 	}
 
 	getPath(): string {
-		return "";
+		return this.path;
 	}
 
 	loadContent(): Promise<Node> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -62,9 +62,16 @@ declare module "ui5-migration" {
 	 */
 	export function CompareReportLevel(l1: ReportLevel, l2: ReportLevel): number;
 
+	export interface FindingLocation {
+		endLine: number;
+		endColumn: number;
+		startLine: number;
+		startColumn: number;
+	}
+
 	export interface Finding {
 		msg: string;
-		loc: {start:number, end:number};
+		location: FindingLocation;
 		filename: string;
 		taskName: string;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -62,6 +62,13 @@ declare module "ui5-migration" {
 	 */
 	export function CompareReportLevel(l1: ReportLevel, l2: ReportLevel): number;
 
+	export interface Finding {
+		msg: string;
+		loc: {start:number, end:number};
+		filename: string;
+		taskName: string;
+	}
+
 	/**
 	 * Used by migration modules to report information or errors.
 	 *
@@ -82,6 +89,20 @@ declare module "ui5-migration" {
 		 * @param {string | number} sValue
 		 */
 		collect(sKey:string, sValue:string|number):void;
+
+		/**
+		 * persists the finding
+		 * @param msg
+		 * @param loc
+		 */
+		storeFinding(msg: string, loc?: ESTree.SourceLocation);
+
+		/**
+		 * get reported entries
+		 */
+		getFindings(): Finding[];
+
+
 
 		/**
 		 * reports the collected information

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -70,9 +70,9 @@ declare module "ui5-migration" {
 	}
 
 	export interface Finding {
-		msg: string;
+		message: string;
 		location: FindingLocation;
-		filename: string;
+		fileName: string;
 		taskName: string;
 	}
 
@@ -99,10 +99,10 @@ declare module "ui5-migration" {
 
 		/**
 		 * persists the finding
-		 * @param msg
+		 * @param message
 		 * @param loc
 		 */
-		storeFinding(msg: string, loc?: ESTree.SourceLocation);
+		storeFinding(message: string, loc?: ESTree.SourceLocation);
 
 		/**
 		 * get reported entries


### PR DESCRIPTION
Since reporters also report findings, they should also be used to store these findings.

Findings indicate that for analyze an exit code of 1 should be the result
As well as for no files found

The idea is to work like eslint
* when lint/analyze runs findings indicate that files are not valid, hence the exit code 1
* when lint --fix/migrate runs there shouldn't be any findings afterwards, hence exit code 0