### PR TITLE
[INTERNAL] replaceGlobals: Improve error messaging for replacements without replacer

### DIFF
--- a/src/tasks/replaceGlobals.ts
+++ b/src/tasks/replaceGlobals.ts
@@ -660,6 +660,11 @@ async function migrate(args: Mod.MigrateArguments): Promise<boolean> {
 
 		// Try to replace the call
 		try {
+			// if there is no replacer configured error out
+			if (!mReplacerFuncs[oReplace.import.replacerName]) {
+				throw Error(`replacement ignored, no replacer configured for ${
+					oReplace.oldImportName}`);
+			}
 			const oResult =
 				mReplacerFuncs[oReplace.import.replacerName].replace(
 					oNodePath, oReplace.import.requireName,

--- a/test/replaceGlobals/sapextend.config.json
+++ b/test/replaceGlobals/sapextend.config.json
@@ -1,0 +1,16 @@
+{
+	"modules": {
+		"jquery.sap.script": {
+			"jQuery.sap.extend": {
+				"version": "1.58.0"
+			}
+		}
+	},
+	"replacers": {
+		"mergeOrObjectAssign": "tasks/helpers/replacers/mergeOrObjectAssign.js"
+	},
+	"comments": {
+		"unhandledReplacementComment": "TODO unhandled replacement"
+	},
+	"excludes": []
+}

--- a/test/replaceGlobals/sapextend.expected.js
+++ b/test/replaceGlobals/sapextend.expected.js
@@ -1,0 +1,34 @@
+/*!
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define([],
+	function() {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function (oParam, sContent) {
+
+			if (oParam.control(0)) {
+				var sKey = "Test." + iconName + oParam.control;
+				if (iconInfo.resourceBundle.hasText(sKey)) {
+					$(sKey).control(jQuery.sap.extend(true, sKey, sContent));
+				}
+				var x$ = jQuery.sap.extend(true, sKey, sContent);
+				x$.control();
+			}
+		};
+
+		return A;
+	}, /* bExport= */ true);

--- a/test/replaceGlobals/sapextend.js
+++ b/test/replaceGlobals/sapextend.js
@@ -1,0 +1,34 @@
+/*!
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define([],
+	function() {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function (oParam, sContent) {
+
+			if (oParam.control(0)) {
+				var sKey = "Test." + iconName + oParam.control;
+				if (iconInfo.resourceBundle.hasText(sKey)) {
+					$(sKey).control(jQuery.sap.extend(true, sKey, sContent));
+				}
+				var x$ = jQuery.sap.extend(true, sKey, sContent);
+				x$.control();
+			}
+		};
+
+		return A;
+	}, /* bExport= */ true);

--- a/test/replaceGlobalsTest.ts
+++ b/test/replaceGlobalsTest.ts
@@ -1897,6 +1897,25 @@ describe("replaceGlobals", function() {
 				]);
 			});
 
+			it("should replace and add dependency for sap extend", function(done) {
+				const expectedContent =
+					fs.readFileSync(rootDir + "sapextend.expected.js", "utf8");
+				const config = JSON.parse(
+					fs.readFileSync(rootDir + "sapextend.config.json", "utf8"));
+				const module = new CustomFileInfo(rootDir + "sapextend.js");
+				analyseMigrateAndTest(module, false, expectedContent, config, done, [
+					"trace: 26: Deprecated call of type ModuleFunction",
+					"trace: 26: Found call to replace \"jQuery.sap.extend\"",
+					"trace: 28: Deprecated call of type ModuleFunction",
+					"trace: 28: Found call to replace \"jQuery.sap.extend\"",
+					"debug: 26: ignored element: jQuery.sap.extend",
+					"error: 26: Error: replacement ignored, no replacer configured for jQuery.sap.extend",
+					"debug: 28: ignored element: jQuery.sap.extend",
+					"error: 28: Error: replacement ignored, no replacer configured for jQuery.sap.extend"
+
+				]);
+			});
+
 			it("should replace and leave dependency for assign", function(done) {
 				const expectedContent =
 					fs.readFileSync(rootDir + "assign.expected.js", "utf8");
@@ -1931,7 +1950,7 @@ describe("replaceGlobals", function() {
 					   module, true, expectedContent, config, done,
 					   [
 						   "debug: 23: ignored element: jQuery.sap.uid",
-						   "error: 23: Error: Cannot read property 'replace' of undefined"
+						   "error: 23: Error: replacement ignored, no replacer configured for jQuery.sap.uid"
 					   ],
 					   "debug", "1.55.0");
 			   });


### PR DESCRIPTION
replaceGlobals Task:
When no replacer is configured a proper error message is now shown.
Similar to using the LEAVE replacer.