### PR TITLE
[INTERNAL] add resolveJsonModules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 		"newLine": "lf",
 		"strict": false,
 		"noImplicitReturns": true,
+		"resolveJsonModule": true,
 		"typeRoots": [
 			"typings",
 			"node_modules/@types"


### PR DESCRIPTION
The [globals](https://www.npmjs.com/package/globals) module was updated to [12.1.1](https://github.com/sindresorhus/globals/releases/tag/v12.1.1). It was switched to typescript and introduced a index.d.ts file in which a json file was required ([change](https://github.com/sindresorhus/globals/blob/master/index.d.ts#L2)).
This causes the error mentioned below because by default TypeScript does not allow importing JSON files.


TypeScript 2.9 has option "resolveJsonModule" which allows importing
and extraction of json files ([resolveJsonModule](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#new---resolvejsonmodule)).

This will fix the currently occurring error:

> > @ui5/migration@0.1.2 prepare /home/node/repository
> > rimraf js && npm run build
> 
> 
> > @ui5/migration@0.1.2 build /home/node/repository
> > tsc -p .
> 
> [96mnode_modules/globals/index.d.ts[0m:[93m2[0m:[93m30[0m - [91merror[0m[90m TS2732: [0mCannot find module './globals.json'. Consider using '--resolveJsonModule' to import module with '.json' extension
> 
> [7m2[0m import globalsJson = require('./globals.json');
> [7m [0m [91m                             ~~~~~~~~~~~~~~~~[0m
> 
> 
> Found 2 errors.