### PR TITLE
[FEATURE] Support multiple versions for same function-call

### DIFF
--- a/src/tasks/replaceGlobals.ts
+++ b/src/tasks/replaceGlobals.ts
@@ -47,7 +47,10 @@ import {Reporter} from "../reporter/Reporter";
 import * as ASTUtils from "../util/ASTUtils";
 import {ASTVisitor, NodePath, TNodePath} from "../util/ASTVisitor";
 import * as CommentUtils from "../util/CommentUtils";
-import {modifyModulesNotMatchingTargetVersion} from "../util/ConfigUtils";
+import {
+	mergeModulesWithMultipleVersions,
+	modifyModulesNotMatchingTargetVersion,
+} from "../util/ConfigUtils";
 import {SapUiDefineCall} from "../util/SapUiDefineCall";
 
 function findVariableNames(ast: ESTree.Node, visitor: ASTVisitor): Set<string> {
@@ -427,7 +430,7 @@ async function analyse(args: Mod.AnalyseArguments): Promise<{}> {
 		return null;
 	}
 
-	const oConfig =
+	let oConfig =
 		args.targetVersion !== "latest"
 			? modifyModulesNotMatchingTargetVersion(
 					args.config,
@@ -436,6 +439,8 @@ async function analyse(args: Mod.AnalyseArguments): Promise<{}> {
 					{alias: "LEAVE", file: "tasks/helpers/replacers/LEAVE.js"}
 			  )
 			: args.config;
+
+	oConfig = mergeModulesWithMultipleVersions(oConfig, args.targetVersion);
 
 	const oModuleTree: ModuleTree = {};
 

--- a/src/util/ConfigUtils.ts
+++ b/src/util/ConfigUtils.ts
@@ -258,13 +258,11 @@ export function mergeModulesWithMultipleVersions(
 	// create a copy of modules
 	const oModules = JSON.parse(JSON.stringify(oModifiedConfig["modules"]));
 	Object.keys(oModules).forEach(sModuleGroup => {
-
 		// get all keys with multiple versions
 		const multiVersionModuleKeys = Object.keys(
 			oModules[sModuleGroup]
 		).filter(sModule => sModule.includes("@"));
 		if (multiVersionModuleKeys.length > 0) {
-
 			// group multiple version modules by module
 			const groupByModule = {};
 			multiVersionModuleKeys.forEach(sKey => {
@@ -288,7 +286,10 @@ export function mergeModulesWithMultipleVersions(
 						matchesVersion(targetVersion, version)
 					) {
 						// get closest
-						if (!localClosest || hasHigherVersion(version, localClosest.version)) {
+						if (
+							!localClosest ||
+							hasHigherVersion(version, localClosest.version)
+						) {
 							localClosest = {
 								key: sKey,
 								sModule,

--- a/src/util/ConfigUtils.ts
+++ b/src/util/ConfigUtils.ts
@@ -20,6 +20,22 @@ export function matchesVersion(targetVersion, version): boolean {
 }
 
 /**
+ *
+ * @param version
+ * @param baselineVersion
+ * @returns {boolean} whether or not version is higher than baselineVersion
+ */
+export function hasHigherVersion(version: string, baselineVersion: string) {
+	if (version === "latest") {
+		return true;
+	}
+	return semver.gt(
+		semver.minVersion(version),
+		semver.minVersion(baselineVersion)
+	);
+}
+
+/**
  * Filters out modules with versions which don't match the target version
  *
  * @param {object} oModules - modules to filter e.g. {"jQuery modifiers": { "jQqery.sap.byId": {version: "1.2.x"} } }
@@ -146,7 +162,7 @@ export function removeModulesNotMatchingTargetVersion(
  */
 export function modifyModulesNotMatchingTargetVersion(
 	oConfig: object,
-	targetVersion,
+	targetVersion: string,
 	targetModuleConfig: object,
 	targetReplacer?: {alias: string; file: string}
 ) {
@@ -166,5 +182,132 @@ export function modifyModulesNotMatchingTargetVersion(
 		oModifiedConfig["replacers"][targetReplacer.alias] =
 			targetReplacer.file;
 	}
+	return oModifiedConfig;
+}
+
+/**
+ * Merges the same modules with different versions
+ *
+ * Before:
+ * "modules": {
+ *		"jquery.sap.script": {
+ *			"jQuery.sap.extend@1.58.0": {
+ *				"newModulePath": "sap/ui/thirdparty/jquery",
+ *				"newVariableName": "jQuery",
+ *				"functionName": "extend",
+ *				"replacer": "jQueryExtend",
+ *				"version": "^1.58.0"
+ *			},
+ *			"jQuery.sap.extend@1.60.0": {
+ *				"newModulePath": "sap/base/util/merge",
+ *				"newVariableName": "merge",
+ *				"replacer": "mergeOrObjectAssign",
+ *				"version": "1.60.0"
+ *			}
+ *		}
+ *	}
+ *
+ * E.g. when using version "latest"
+ * After:
+ * "modules": {
+ *		"jquery.sap.script": {
+ *			"jQuery.sap.extend": {
+ *				"newModulePath": "sap/base/util/merge",
+ *				"newVariableName": "merge",
+ *				"replacer": "mergeOrObjectAssign",
+ *				"version": "1.60.0"
+ *			},
+ *			"jQuery.sap.extend@1.58.0": {
+ *				"newModulePath": "sap/ui/thirdparty/jquery",
+ *				"newVariableName": "jQuery",
+ *				"functionName": "extend",
+ *				"replacer": "jQueryExtend",
+ *				"version": "^1.58.0"
+ *			},
+ *			"jQuery.sap.extend@1.60.0": {
+ *				"newModulePath": "sap/base/util/merge",
+ *				"newVariableName": "merge",
+ *				"replacer": "mergeOrObjectAssign",
+ *				"version": "1.60.0"
+ *			}
+ *		}
+ *	}
+ *
+ * @param {object} oConfig config to modify
+ * @param {string} targetVersion UI5 target version e.g. 1.58.0
+ * @returns {object} a copy of the config with closest versions to targetVersion of modules for
+ * keys which have an '@' in the name.
+ * E.g. keys ["jQuery.sap.extend@1.60.0", "jQuery.sap.extend@1.58.0"]
+ * will be ["jQuery.sap.extend@1.60.0", "jQuery.sap.extend@1.58.0", "jQuery.sap.extend"] where "jQuery.sap.extend" is a copy of the closest matching version,
+ * e.g. "1.60.0" for targetVersion "latest"
+ */
+export function mergeModulesWithMultipleVersions(
+	oConfig: object,
+	targetVersion: string
+) {
+	// validate input parameters
+	if (!oConfig) {
+		throw new Error("No config supplied for modification");
+	}
+
+	const oModifiedConfig = JSON.parse(JSON.stringify(oConfig));
+	if (Object.keys(oConfig).length === 0 || !targetVersion) {
+		return oModifiedConfig;
+	}
+
+	// create a copy of modules
+	const oModules = JSON.parse(JSON.stringify(oModifiedConfig["modules"]));
+	Object.keys(oModules).forEach(sModuleGroup => {
+
+		// get all keys with multiple versions
+		const multiVersionModuleKeys = Object.keys(
+			oModules[sModuleGroup]
+		).filter(sModule => sModule.includes("@"));
+		if (multiVersionModuleKeys.length > 0) {
+
+			// group multiple version modules by module
+			const groupByModule = {};
+			multiVersionModuleKeys.forEach(sKey => {
+				const sModule = sKey.split("@")[0];
+				if (!groupByModule[sModule]) {
+					groupByModule[sModule] = [];
+				}
+				groupByModule[sModule].push(sKey);
+			});
+
+			//get highest version
+			const closestModules = [];
+			Object.keys(groupByModule).forEach(sModule => {
+				let localClosest;
+
+				groupByModule[sModule].filter(sKey => {
+					const version = oModules[sModuleGroup][sKey].version;
+
+					if (
+						targetVersion === "latest" ||
+						matchesVersion(targetVersion, version)
+					) {
+						// get closest
+						if (!localClosest || hasHigherVersion(version, localClosest.version)) {
+							localClosest = {
+								key: sKey,
+								sModule,
+								version,
+							};
+						}
+					}
+				});
+				if (localClosest) {
+					closestModules.push(localClosest);
+				}
+			});
+			closestModules.forEach(high => {
+				oModules[sModuleGroup][high.sModule] =
+					oModules[sModuleGroup][high.key];
+			});
+		}
+	});
+	oModifiedConfig["modules"] = oModules;
+
 	return oModifiedConfig;
 }

--- a/src/util/ConfigUtils.ts
+++ b/src/util/ConfigUtils.ts
@@ -38,7 +38,7 @@ export function hasHigherVersion(version: string, baselineVersion: string) {
 /**
  * Filters out modules with versions which don't match the target version
  *
- * @param {object} oModules - modules to filter e.g. {"jQuery modifiers": { "jQqery.sap.byId": {version: "1.2.x"} } }
+ * @param {object} oModules - modules to filter e.g. {"jQuery modifiers": { "jQuery.sap.byId": {version: "1.2.x"} } }
  * @param {string} targetVersion - target version
  * @returns {object}
  */
@@ -215,7 +215,7 @@ export function modifyModulesNotMatchingTargetVersion(
  *				"newModulePath": "sap/base/util/merge",
  *				"newVariableName": "merge",
  *				"replacer": "mergeOrObjectAssign",
- *				"version": "1.60.0"
+ *				"version": "1.71.0"
  *			},
  *			"jQuery.sap.extend@1.58.0": {
  *				"newModulePath": "sap/ui/thirdparty/jquery",
@@ -264,6 +264,15 @@ export function mergeModulesWithMultipleVersions(
 		).filter(sModule => sModule.includes("@"));
 		if (multiVersionModuleKeys.length > 0) {
 			// group multiple version modules by module
+			/**
+			 *
+			 * {
+			 *     "jQuery.sap.extend": [
+			 *     		"jQuery.sap.extend@1.58.0",
+			 *     		"jQuery.sap.extend@1.60.0"
+			 *     	]
+			 * }
+			 */
 			const groupByModule = {};
 			multiVersionModuleKeys.forEach(sKey => {
 				const sModule = sKey.split("@")[0];
@@ -276,16 +285,19 @@ export function mergeModulesWithMultipleVersions(
 			//get highest version
 			const closestModules = [];
 			Object.keys(groupByModule).forEach(sModule => {
+				// sModule, e.g. "jQuery.sap.extend"
 				let localClosest;
 
-				groupByModule[sModule].filter(sKey => {
+				groupByModule[sModule].forEach(sKey => {
 					const version = oModules[sModuleGroup][sKey].version;
+					// e.g. ^1.58.0
 
+					// check if version is a valid candidate (e.g. is not bigger than targetVersion)
 					if (
 						targetVersion === "latest" ||
 						matchesVersion(targetVersion, version)
 					) {
-						// get closest
+						// get closest to the targetVersion
 						if (
 							!localClosest ||
 							hasHigherVersion(version, localClosest.version)
@@ -302,6 +314,8 @@ export function mergeModulesWithMultipleVersions(
 					closestModules.push(localClosest);
 				}
 			});
+
+			// replace modules with closest ones
 			closestModules.forEach(high => {
 				oModules[sModuleGroup][high.sModule] =
 					oModules[sModuleGroup][high.key];

--- a/src/util/ConfigUtils.ts
+++ b/src/util/ConfigUtils.ts
@@ -208,6 +208,8 @@ export function modifyModulesNotMatchingTargetVersion(
  *	}
  *
  * E.g. when using version "latest"
+ * the object "jQuery.sap.extend@1.60.0" is copied to "jQuery.sap.extend"
+ * which means that it is taken into account for replacements
  * After:
  * "modules": {
  *		"jquery.sap.script": {
@@ -215,7 +217,7 @@ export function modifyModulesNotMatchingTargetVersion(
  *				"newModulePath": "sap/base/util/merge",
  *				"newVariableName": "merge",
  *				"replacer": "mergeOrObjectAssign",
- *				"version": "1.71.0"
+ *				"version": "1.60.0"
  *			},
  *			"jQuery.sap.extend@1.58.0": {
  *				"newModulePath": "sap/ui/thirdparty/jquery",

--- a/test/replaceGlobals/multiversion.1.58.0.expected.js
+++ b/test/replaceGlobals/multiversion.1.58.0.expected.js
@@ -1,0 +1,36 @@
+/*!
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["sap/ui/thirdparty/jquery"],
+	function(jQuery0) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function (oParam, sContent) {
+
+			if (oParam.control(0)) {
+				var sKey = "Test." + iconName + oParam.control;
+				if (iconInfo.resourceBundle.hasText(sKey)) {
+					$(sKey).control(jQuery0.extend(false, {}, sKey, sContent));
+				}
+				var x$ = jQuery0.extend(false, sKey, sContent);
+				x$ += jQuery0.extend(sKey, sContent);
+				x$ += Object.assign({}, sContent);
+				x$.control();
+			}
+		};
+
+		return A;
+	}, /* bExport= */ true);

--- a/test/replaceGlobals/multiversion.config.json
+++ b/test/replaceGlobals/multiversion.config.json
@@ -1,0 +1,27 @@
+{
+	"modules": {
+		"jquery.sap.script": {
+			"jQuery.sap.extend@1.58.0": {
+				"newModulePath": "sap/ui/thirdparty/jquery",
+				"newVariableName": "jQuery",
+				"functionName": "extend",
+				"replacer": "jQueryExtend",
+				"version": "^1.58.0"
+			},
+			"jQuery.sap.extend@1.60.0": {
+				"newModulePath": "sap/base/util/merge",
+				"newVariableName": "merge",
+				"replacer": "mergeOrObjectAssign",
+				"version": "1.60.0"
+			}
+		}
+	},
+	"replacers": {
+		"mergeOrObjectAssign": "tasks/helpers/replacers/mergeOrObjectAssign.js",
+		"jQueryExtend": "tasks/helpers/replacers/jQueryExtend.js"
+	},
+	"comments": {
+		"unhandledReplacementComment": "TODO unhandled replacement"
+	},
+	"excludes": []
+}

--- a/test/replaceGlobals/multiversion.expected.js
+++ b/test/replaceGlobals/multiversion.expected.js
@@ -1,0 +1,36 @@
+/*!
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define([],
+	function() {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function (oParam, sContent) {
+
+			if (oParam.control(0)) {
+				var sKey = "Test." + iconName + oParam.control;
+				if (iconInfo.resourceBundle.hasText(sKey)) {
+					$(sKey).control(Object.assign({}, sKey, sContent));
+				}
+				var x$ = Object.assign(sKey, sContent);
+				x$ += Object.assign(sKey, sContent);
+				x$ += Object.assign({}, sContent);
+				x$.control();
+			}
+		};
+
+		return A;
+	}, /* bExport= */ true);

--- a/test/replaceGlobals/multiversion.js
+++ b/test/replaceGlobals/multiversion.js
@@ -1,0 +1,36 @@
+/*!
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define([],
+	function() {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function (oParam, sContent) {
+
+			if (oParam.control(0)) {
+				var sKey = "Test." + iconName + oParam.control;
+				if (iconInfo.resourceBundle.hasText(sKey)) {
+					$(sKey).control(jQuery.sap.extend(false, {}, sKey, sContent));
+				}
+				var x$ = jQuery.sap.extend(false, sKey, sContent);
+				x$ += jQuery.sap.extend(sKey, sContent);
+				x$ += jQuery.sap.extend({}, sContent);
+				x$.control();
+			}
+		};
+
+		return A;
+	}, /* bExport= */ true);

--- a/test/replaceGlobalsTest.ts
+++ b/test/replaceGlobalsTest.ts
@@ -2498,5 +2498,99 @@ describe("replaceGlobals", function() {
 				[]
 			);
 		});
+
+		it("multiversion latest", function(done) {
+			const expectedContent = fs.readFileSync(
+				rootDir + "multiversion.expected.js",
+				"utf8"
+			);
+			const config = JSON.parse(
+				fs.readFileSync(rootDir + "multiversion.config.json", "utf8")
+			);
+			const module = new CustomFileInfo(rootDir + "multiversion.js");
+			analyseMigrateAndTest(module, true, expectedContent, config, done, [
+				'trace: 26: Replace global call with "sap.base.util.merge"',
+				'trace: 26: Found call to replace "jQuery.sap.extend"',
+				'trace: 28: Replace global call with "sap.base.util.merge"',
+				'trace: 28: Found call to replace "jQuery.sap.extend"',
+				'trace: 29: Replace global call with "sap.base.util.merge"',
+				'trace: 29: Found call to replace "jQuery.sap.extend"',
+				'trace: 30: Replace global call with "sap.base.util.merge"',
+				'trace: 30: Found call to replace "jQuery.sap.extend"',
+				'trace: 26: Replaced call "jQuery.sap.extend"',
+				'trace: 28: Replaced call "jQuery.sap.extend"',
+				'trace: 29: Replaced call "jQuery.sap.extend"',
+				'trace: 30: Replaced call "jQuery.sap.extend"',
+			]);
+		});
+
+		it("multiversion version 1.60.0", function(done) {
+			const expectedContent = fs.readFileSync(
+				rootDir + "multiversion.expected.js",
+				"utf8"
+			);
+			const config = JSON.parse(
+				fs.readFileSync(rootDir + "multiversion.config.json", "utf8")
+			);
+			const module = new CustomFileInfo(rootDir + "multiversion.js");
+			analyseMigrateAndTest(
+				module,
+				true,
+				expectedContent,
+				config,
+				done,
+				[
+					'trace: 26: Replace global call with "sap.base.util.merge"',
+					'trace: 26: Found call to replace "jQuery.sap.extend"',
+					'trace: 28: Replace global call with "sap.base.util.merge"',
+					'trace: 28: Found call to replace "jQuery.sap.extend"',
+					'trace: 29: Replace global call with "sap.base.util.merge"',
+					'trace: 29: Found call to replace "jQuery.sap.extend"',
+					'trace: 30: Replace global call with "sap.base.util.merge"',
+					'trace: 30: Found call to replace "jQuery.sap.extend"',
+					'trace: 26: Replaced call "jQuery.sap.extend"',
+					'trace: 28: Replaced call "jQuery.sap.extend"',
+					'trace: 29: Replaced call "jQuery.sap.extend"',
+					'trace: 30: Replaced call "jQuery.sap.extend"',
+				],
+				"trace",
+				"1.60.0"
+			);
+		});
+
+		it("multiversion version 1.58.0", function(done) {
+			const expectedContent = fs.readFileSync(
+				rootDir + "multiversion.1.58.0.expected.js",
+				"utf8"
+			);
+			const config = JSON.parse(
+				fs.readFileSync(rootDir + "multiversion.config.json", "utf8")
+			);
+			const module = new CustomFileInfo(rootDir + "multiversion.js");
+			analyseMigrateAndTest(
+				module,
+				true,
+				expectedContent,
+				config,
+				done,
+				[
+					'trace: 26: Replace global call with "sap.ui.thirdparty.jquery"',
+					'trace: 26: Found call to replace "jQuery.sap.extend"',
+					'trace: 28: Replace global call with "sap.ui.thirdparty.jquery"',
+					'trace: 28: Found call to replace "jQuery.sap.extend"',
+					'trace: 29: Replace global call with "sap.ui.thirdparty.jquery"',
+					'trace: 29: Found call to replace "jQuery.sap.extend"',
+					'trace: 30: Replace global call with "sap.ui.thirdparty.jquery"',
+					'trace: 30: Found call to replace "jQuery.sap.extend"',
+					'trace: 26: Replaced call "jQuery.sap.extend"',
+					'trace: 28: Replaced call "jQuery.sap.extend"',
+					'trace: 29: Replaced call "jQuery.sap.extend"',
+					'trace: 30: Replaced call "jQuery.sap.extend"',
+					'trace: 7: Add dependency "sap/ui/thirdparty/jquery" named "jQuery0"',
+				],
+				"trace",
+				"1.58.0"
+			);
+		});
 	});
 });


### PR DESCRIPTION
replacer now supports multiple versions by adding version separated by "@".
E.g. "jQuery.sap.extend@1.60.0"
The closest valid version to the target version is then taken as replacement.


E.g.
```json
 "jquery.sap.script": {
 	"jQuery.sap.extend@1.58.0": {
 		"newModulePath": "sap/ui/thirdparty/jquery",
 		"newVariableName": "jQuery",
 		"functionName": "extend",
 		"replacer": "jQueryExtend",
 		"version": "^1.58.0"
 	},
 	"jQuery.sap.extend@1.60.0": {
 		"newModulePath": "sap/base/util/merge",
 		"newVariableName": "merge",
 		"replacer": "mergeOrObjectAssign",
 		"version": "1.60.0"
 	}
 }
```
can now be defined and the one closest to the `targetVersion` is taken

targetVersion `1.59.0` takes replacement of `1.58.0`
targetVersion `1.70.0` takes replacement of `1.60.0`
targetVersion `latest` takes replacement of `1.60.0`

Fixes: #74