### PR TITLE
[INTERNAL] update azure pipelines macos image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ strategy:
       imageName: 'ubuntu-16.04'
       node_version: 11.x
     mac_node_latest:
-      imageName: 'macos-10.13'
+      imageName: 'macos-10.14'
       node_version: 11.x
     windows_node_latest:
       imageName: 'vs2017-win2016'


### PR DESCRIPTION
Replace macos image which is not supported anymore with newer version.


Fixes error:
```
##[warning]An image label with the label macos-10.13 does not exist.
,##[error]The remote provider was unable to process the request.
```

From azure-pipelines:

>  Important
> 
> On March 23, 2020, we'll be removing the following Azure Pipelines hosted images:
> 
> Windows Server 2012R2 with Visual Studio 2015 (vs2015-win2012r2)
> macOS X High Sierra 10.13 (macOS-10.13)
> Windows Server Core 1803 - (win1803)
> Customers are encouraged to migrate to vs2017-win2016, macOS-10.14, or a self-hosted agent respectively.

source: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops