### PR TITLE
[INTERNAL] package.json: Move project build into separate npm script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ steps:
     displayName: 'Install Node.js'
 
   - script: npm ci
+  - script: npm run build
   - script: npm run test-azure
 
   - task: PublishTestResults@2

--- a/package.json
+++ b/package.json
@@ -16,9 +16,8 @@
     "node": ">=8.5"
   },
   "scripts": {
-    "build": "tsc -p .",
-    "build-watch": "tsc -w -p .",
-    "prepare": "rimraf js && npm run build",
+    "build": "rimraf js && tsc -p .",
+    "build-watch": "rimraf js && tsc -w -p .",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "test": "npm run lint && npm run check && npm run coverage",
     "test-azure": "npm run lint && npm run check && npm run unit && npm run coverage-junit",
@@ -32,9 +31,8 @@
     "fix": "gts fix",
     "preversion": "npm test",
     "version": "git-chglog --next-tag v$npm_package_version -o CHANGELOG.md && git add CHANGELOG.md",
-    "postversion": "git push --follow-tags",
-    "release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version",
-    "compile": "tsc -p ."
+    "prepublishOnly": "git push --follow-tags",
+    "release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version"
   },
   "types": "typings/index.d.ts",
   "files": [


### PR DESCRIPTION
The workaround discussed in https://github.com/SAP/ui5-cli/issues/308
was implemented in our CI. Howver, to be able to still build the
project (using devDependencies) before pruning the required
devDependencies, the build needs to be executed explicitly
before the prune step. Apparently there seems to be no suitable standard
hook for this use case.

Also use prepublishOnly hook for git push as per
https://github.com/SAP/ui5-cli/commit/d0e541d21f1ef2511fb0588071ea7812caaa5db4