### PR TITLE
[INTERNAL] build: run build before test

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "check": "gts check",
     "clean": "gts clean",
     "fix": "gts fix",
-    "preversion": "npm test",
+    "preversion": "npm run build && npm test",
     "version": "git-chglog --next-tag v$npm_package_version -o CHANGELOG.md && git add CHANGELOG.md",
     "prepublishOnly": "git push --follow-tags",
     "release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version"


### PR DESCRIPTION
Run build before test during preversion to ensure that
tests can be executed on compiled resources.