### PR TITLE
[FEATURE] Migration of jQuery.sap.*Whitelist: Replace insensitive terms with inclusive language

### DIFF
--- a/defaultConfig/replaceGlobals.config.json
+++ b/defaultConfig/replaceGlobals.config.json
@@ -535,30 +535,56 @@
 				"newModulePath": "sap/base/security/sanitizeHTML",
 				"version": "^1.58.0"
 			},
-			"jQuery.sap.clearUrlWhitelist": {
+			"jQuery.sap.clearUrlWhitelist@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"functionName": "clear",
 				"version": "^1.58.0"
 			},
-			"jQuery.sap.removeUrlWhitelist": {
+			"jQuery.sap.removeUrlWhitelist@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"replacer": "RemoveUrlWhitelist",
 				"version": "^1.58.0"
 			},
-			"jQuery.sap.addUrlWhitelist": {
+			"jQuery.sap.addUrlWhitelist@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"functionName": "add",
 				"version": "^1.58.0"
 			},
-			"jQuery.sap.getUrlWhitelist": {
+			"jQuery.sap.getUrlWhitelist@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"functionName": "entries",
 				"version": "^1.58.0"
 			},
-			"jQuery.sap.validateUrl": {
+			"jQuery.sap.validateUrl@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"functionName": "validate",
 				"version": "^1.58.0"
+			},
+			"jQuery.sap.clearUrlWhitelist@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "clear",
+				"version": "^1.85.0"
+			},
+			"jQuery.sap.removeUrlWhitelist@1.85.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.85.0",
+				"errorComment": " TODO: migration not possible. jQuery.sap.encoder is deprecated. Please use <code>sap.base.security.URLListValidator</code>"
+			},
+			"jQuery.sap.addUrlWhitelist@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "add",
+				"version": "^1.85.0"
+			},
+			"jQuery.sap.getUrlWhitelist@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "entries",
+				"version": "^1.85.0"
+			},
+			"jQuery.sap.validateUrl@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "validate",
+				"version": "^1.85.0"
 			},
 			"$.sap.encodeHTML": {
 				"newModulePath": "sap/base/security/encodeXML",
@@ -596,30 +622,56 @@
 				"newModulePath": "sap/base/security/sanitizeHTML",
 				"version": "^1.58.0"
 			},
-			"$.sap.clearUrlWhitelist": {
+			"$.sap.clearUrlWhitelist@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"functionName": "clear",
 				"version": "^1.58.0"
 			},
-			"$.sap.removeUrlWhitelist": {
+			"$.sap.removeUrlWhitelist@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"replacer": "RemoveUrlWhitelist",
 				"version": "^1.58.0"
 			},
-			"$.sap.addUrlWhitelist": {
+			"$.sap.addUrlWhitelist@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"functionName": "add",
 				"version": "^1.58.0"
 			},
-			"$.sap.getUrlWhitelist": {
+			"$.sap.getUrlWhitelist@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"functionName": "entries",
 				"version": "^1.58.0"
 			},
-			"$.sap.validateUrl": {
+			"$.sap.validateUrl@1.58.0": {
 				"newModulePath": "sap/base/security/URLWhitelist",
 				"functionName": "validate",
 				"version": "^1.58.0"
+			},
+			"$.sap.clearUrlWhitelist@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "clear",
+				"version": "^1.85.0"
+			},
+			"$.sap.removeUrlWhitelist@1.85.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.85.0",
+				"errorComment": " TODO: migration not possible. $.sap.encoder is deprecated. Please use <code>sap.base.security.URLListValidator</code>"
+			},
+			"$.sap.addUrlWhitelist@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "add",
+				"version": "^1.85.0"
+			},
+			"$.sap.getUrlWhitelist@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "entries",
+				"version": "^1.85.0"
+			},
+			"$.sap.validateUrl@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "validate",
+				"version": "^1.85.0"
 			}
 		},
 		"jquery.sap.sjax": {
@@ -3117,6 +3169,59 @@
 			"Storage.getInstance": {
 				"newModulePath": "sap/ui/util/Storage",
 				"replacer": "NewInstance",
+				"version": "^1.58.0"
+			}
+		},
+		"sap/base/security/URLWhitelist": {
+			"URLWhitelist.clear@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"newVariableName": "URLListValidator",
+				"version": "^1.85.0"
+			},
+			"URLWhitelist.add@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"newVariableName": "URLListValidator",
+				"version": "^1.85.0"
+			},
+			"URLWhitelist.entries@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"newVariableName": "URLListValidator",
+				"version": "^1.85.0"
+			},
+			"URLWhitelist.validate@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"newVariableName": "URLListValidator",
+				"version": "^1.85.0"
+			},
+			"URLWhitelist.delete@1.85.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.85.0",
+				"errorComment": " TODO: migration not possible. Use sap/base/security/URLListValidator.clear and sap/base/security/URLListValidator.add instead."
+			},
+			"URLWhitelist.clear@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.58.0"
+			},
+			"URLWhitelist.add@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.58.0"
+			},
+			"URLWhitelist.entries@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.58.0"
+			},
+			"URLWhitelist.validate@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.58.0"
+			},
+			"URLWhitelist.delete@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
 				"version": "^1.58.0"
 			}
 		}

--- a/src/tasks/helpers/replacers/startsOrEndsWithIgnoreCase.ts
+++ b/src/tasks/helpers/replacers/startsOrEndsWithIgnoreCase.ts
@@ -38,7 +38,7 @@ function isWithinIfStatement(node: NodePath) {
  * pattern)</code> with
  * <code>value.toLowerCase().startsWith(pattern.toLowerCase())</code> The
  * parameter config.startsOrEndsWithFunction is used to switch between the
- * replacments.
+ * replacements.
  *
  * @param {recast.NodePath} node The top node of the module reference
  * @param {string} name The name of the new module

--- a/src/tasks/replaceGlobals.ts
+++ b/src/tasks/replaceGlobals.ts
@@ -858,7 +858,7 @@ async function migrate(args: Mod.MigrateArguments): Promise<boolean> {
 		aUsedNewModules.has(r.modulePath)
 	);
 	const removeRequires = analyseResult.removeRequires.filter(
-		r => !aDoNotRemoveModules.has(r)
+		r => !aDoNotRemoveModules.has(r) && !aUsedNewModules.has(r)
 	);
 
 	const aRequireNames = removeRequires.map(s =>

--- a/test/replaceGlobals/inclusive.config.json
+++ b/test/replaceGlobals/inclusive.config.json
@@ -1,0 +1,117 @@
+{
+	"modules": {
+		"jquery.sap.encoder": {
+			"jQuery.sap.clearUrlWhitelist@1.58.0": {
+				"newModulePath": "sap/base/security/URLWhitelist",
+				"functionName": "clear",
+				"version": "^1.58.0"
+			},
+			"jQuery.sap.removeUrlWhitelist@1.58.0": {
+				"newModulePath": "sap/base/security/URLWhitelist",
+				"replacer": "RemoveUrlWhitelist",
+				"version": "^1.58.0"
+			},
+			"jQuery.sap.addUrlWhitelist@1.58.0": {
+				"newModulePath": "sap/base/security/URLWhitelist",
+				"functionName": "add",
+				"version": "^1.58.0"
+			},
+			"jQuery.sap.getUrlWhitelist@1.58.0": {
+				"newModulePath": "sap/base/security/URLWhitelist",
+				"functionName": "entries",
+				"version": "^1.58.0"
+			},
+			"jQuery.sap.validateUrl@1.58.0": {
+				"newModulePath": "sap/base/security/URLWhitelist",
+				"functionName": "validate",
+				"version": "^1.58.0"
+			},
+			"jQuery.sap.clearUrlWhitelist@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "clear",
+				"version": "^1.85.0"
+			},
+			"jQuery.sap.removeUrlWhitelist@1.85.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.85.0",
+				"errorComment": " TODO: migration not possible. jQuery.sap.encoder is deprecated. Please use <code>sap.base.security.URLListValidator</code>"
+			},
+			"jQuery.sap.addUrlWhitelist@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "add",
+				"version": "^1.85.0"
+			},
+			"jQuery.sap.getUrlWhitelist@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "entries",
+				"version": "^1.85.0"
+			},
+			"jQuery.sap.validateUrl@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"functionName": "validate",
+				"version": "^1.85.0"
+			}
+		},
+		"sap/base/security/URLWhitelist": {
+			"URLWhitelist.clear@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"newVariableName": "URLListValidator",
+				"version": "^1.85.0"
+			},
+			"URLWhitelist.add@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"newVariableName": "URLListValidator",
+				"version": "^1.85.0"
+			},
+			"URLWhitelist.entries@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"newVariableName": "URLListValidator",
+				"version": "^1.85.0"
+			},
+			"URLWhitelist.validate@1.85.0": {
+				"newModulePath": "sap/base/security/URLListValidator",
+				"newVariableName": "URLListValidator",
+				"version": "^1.85.0"
+			},
+			"URLWhitelist.delete@1.85.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.85.0",
+				"errorComment": " TODO: migration not possible. Use sap/base/security/URLListValidator.clear and sap/base/security/URLListValidator.add instead."
+			},
+			"URLWhitelist.clear@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.58.0"
+			},
+			"URLWhitelist.add@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.58.0"
+			},
+			"URLWhitelist.entries@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.58.0"
+			},
+			"URLWhitelist.validate@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.58.0"
+			},
+			"URLWhitelist.delete@1.58.0": {
+				"newModulePath": "LEAVE",
+				"replacer": "LEAVE",
+				"version": "^1.58.0"
+			}
+		}
+	},
+	"replacers": {
+		"Module": "tasks/helpers/replacers/Module.js",
+		"ModuleFunction": "tasks/helpers/replacers/ModuleFunction.js",
+		"LEAVE": "tasks/helpers/replacers/LEAVE.js",
+		"RemoveUrlWhitelist": "tasks/helpers/replacers/RemoveUrlWhitelist.js"
+	},
+	"excludes": []
+}

--- a/test/replaceGlobals/inclusive158.expected.js
+++ b/test/replaceGlobals/inclusive158.expected.js
@@ -1,0 +1,35 @@
+/* !
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["sap/base/security/URLWhitelist"],
+	function(URLWhitelist) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function(oParam, sContent) {
+			var b = {};
+			var x = 5;
+			this.u = 10;
+
+			URLWhitelist.clear();
+
+			URLWhitelist.delete(URLWhitelist.entries()[oParam]);
+
+			URLWhitelist.add("", "example.com", 1337);
+
+			URLWhitelist.entries();
+			URLWhitelist.validate(sContent);
+		};
+	}, /* bExport= */ true);

--- a/test/replaceGlobals/inclusive158.js
+++ b/test/replaceGlobals/inclusive158.js
@@ -1,0 +1,35 @@
+/* !
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["jquery.sap.encoder"],
+	function(jQuery) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function(oParam, sContent) {
+			var b = {};
+			var x = 5;
+			this.u = 10;
+
+			jQuery.sap.clearUrlWhitelist();
+
+			jQuery.sap.removeUrlWhitelist(oParam);
+
+			jQuery.sap.addUrlWhitelist("", "example.com", 1337);
+
+			jQuery.sap.getUrlWhitelist();
+			jQuery.sap.validateUrl(sContent);
+		};
+	}, /* bExport= */ true);

--- a/test/replaceGlobals/inclusive185.expected.js
+++ b/test/replaceGlobals/inclusive185.expected.js
@@ -1,0 +1,36 @@
+/* !
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["jquery.sap.encoder", "sap/base/security/URLListValidator"],
+	function(jQuery, URLListValidator) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function(oParam, sContent) {
+			var b = {};
+			var x = 5;
+			this.u = 10;
+
+			URLListValidator.clear();
+
+			// TODO: migration not possible. jQuery.sap.encoder is deprecated. Please use <code>sap.base.security.URLListValidator</code>
+			jQuery.sap.removeUrlWhitelist(oParam);
+
+			URLListValidator.add("", "example.com", 1337);
+
+			URLListValidator.entries();
+			URLListValidator.validate(sContent);
+		};
+	}, /* bExport= */ true);

--- a/test/replaceGlobals/inclusive185.js
+++ b/test/replaceGlobals/inclusive185.js
@@ -1,0 +1,35 @@
+/* !
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["jquery.sap.encoder"],
+	function(jQuery) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function(oParam, sContent) {
+			var b = {};
+			var x = 5;
+			this.u = 10;
+
+			jQuery.sap.clearUrlWhitelist();
+
+			jQuery.sap.removeUrlWhitelist(oParam);
+
+			jQuery.sap.addUrlWhitelist("", "example.com", 1337);
+
+			jQuery.sap.getUrlWhitelist();
+			jQuery.sap.validateUrl(sContent);
+		};
+	}, /* bExport= */ true);

--- a/test/replaceGlobals/inclusive190.expected.js
+++ b/test/replaceGlobals/inclusive190.expected.js
@@ -1,0 +1,36 @@
+/* !
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["sap/base/security/URLWhitelist", "sap/base/security/URLListValidator"],
+	function(URLWhitelist, URLListValidator) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function(oParam, sContent) {
+			var b = {};
+			var x = 5;
+			this.u = 10;
+
+			URLListValidator();
+
+			// TODO: migration not possible. Use sap/base/security/URLListValidator.clear and sap/base/security/URLListValidator.add instead.
+			URLWhitelist.delete(URLListValidator()[oParam]);
+
+			URLListValidator("", "example.com", 1337);
+
+			URLListValidator();
+			URLListValidator(sContent);
+		};
+	}, /* bExport= */ true);

--- a/test/replaceGlobals/inclusive190.js
+++ b/test/replaceGlobals/inclusive190.js
@@ -1,0 +1,35 @@
+/* !
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["sap/base/security/URLWhitelist"],
+	function(URLWhitelist) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param sContent
+		 */
+		A.x = function(oParam, sContent) {
+			var b = {};
+			var x = 5;
+			this.u = 10;
+
+			URLWhitelist.clear();
+
+			URLWhitelist.delete(URLWhitelist.entries()[oParam]);
+
+			URLWhitelist.add("", "example.com", 1337);
+
+			URLWhitelist.entries();
+			URLWhitelist.validate(sContent);
+		};
+	}, /* bExport= */ true);

--- a/test/replaceGlobalsTest.ts
+++ b/test/replaceGlobalsTest.ts
@@ -701,6 +701,126 @@ describe("replaceGlobals", function() {
 			]);
 		});
 
+		it("should replaceGlobals inclusive version 1.58.0: jQuery.sap.*Whitelist -> URLWhitelist", function(done) {
+			const expectedContent = fs.readFileSync(
+				rootDir + "inclusive158.expected.js",
+				"utf8"
+			);
+			const config = JSON.parse(
+				fs.readFileSync(rootDir + "inclusive.config.json", "utf8")
+			);
+			const module = new CustomFileInfo(rootDir + "inclusive158.js");
+			analyseMigrateAndTest(
+				module,
+				true,
+				expectedContent,
+				config,
+				done,
+				[
+					'trace: 26: Replace global call with "sap.base.security.URLWhitelist"',
+					'trace: 26: Found call to replace "jQuery.sap.clearUrlWhitelist"',
+					'trace: 28: Replace global call with "sap.base.security.URLWhitelist"',
+					'trace: 28: Found call to replace "jQuery.sap.removeUrlWhitelist"',
+					'trace: 30: Replace global call with "sap.base.security.URLWhitelist"',
+					'trace: 30: Found call to replace "jQuery.sap.addUrlWhitelist"',
+					'trace: 32: Replace global call with "sap.base.security.URLWhitelist"',
+					'trace: 32: Found call to replace "jQuery.sap.getUrlWhitelist"',
+					'trace: 33: Replace global call with "sap.base.security.URLWhitelist"',
+					'trace: 33: Found call to replace "jQuery.sap.validateUrl"',
+					'trace: 26: Replaced call "jQuery.sap.clearUrlWhitelist"',
+					'trace: 28: Replaced call "jQuery.sap.removeUrlWhitelist"',
+					'trace: 30: Replaced call "jQuery.sap.addUrlWhitelist"',
+					'trace: 32: Replaced call "jQuery.sap.getUrlWhitelist"',
+					'trace: 33: Replaced call "jQuery.sap.validateUrl"',
+					'trace: 7: Add dependency "sap/base/security/URLWhitelist" named "URLWhitelist"',
+					'trace: 7: Remove dependency "jquery.sap.encoder"',
+				],
+				"trace",
+				"1.58.0"
+			);
+		});
+
+		it("should replaceGlobals inclusive version to 1.85.0: jQuery.sap.*Whitelist -> URLListValidator", function(done) {
+			const expectedContent = fs.readFileSync(
+				rootDir + "inclusive185.expected.js",
+				"utf8"
+			);
+			const config = JSON.parse(
+				fs.readFileSync(rootDir + "inclusive.config.json", "utf8")
+			);
+			const module = new CustomFileInfo(rootDir + "inclusive185.js");
+			analyseMigrateAndTest(
+				module,
+				true,
+				expectedContent,
+				config,
+				done,
+				[
+					'trace: 26: Replace global call with "sap.base.security.URLListValidator"',
+					'trace: 26: Found call to replace "jQuery.sap.clearUrlWhitelist"',
+					'trace: 28: Replace global call with "LEAVE"',
+					'trace: 28: Found call to replace "jQuery.sap.removeUrlWhitelist"',
+					'trace: 30: Replace global call with "sap.base.security.URLListValidator"',
+					'trace: 30: Found call to replace "jQuery.sap.addUrlWhitelist"',
+					'trace: 32: Replace global call with "sap.base.security.URLListValidator"',
+					'trace: 32: Found call to replace "jQuery.sap.getUrlWhitelist"',
+					'trace: 33: Replace global call with "sap.base.security.URLListValidator"',
+					'trace: 33: Found call to replace "jQuery.sap.validateUrl"',
+					'trace: 26: Replaced call "jQuery.sap.clearUrlWhitelist"',
+					"debug: 28: ignored element: jQuery.sap.removeUrlWhitelist",
+					"error: 28: Error: Ignore",
+					'trace: 30: Replaced call "jQuery.sap.addUrlWhitelist"',
+					'trace: 32: Replaced call "jQuery.sap.getUrlWhitelist"',
+					'trace: 33: Replaced call "jQuery.sap.validateUrl"',
+					'trace: 7: Add dependency "sap/base/security/URLListValidator" named "URLListValidator"',
+				],
+				"trace",
+				"1.85.0"
+			);
+		});
+
+		it("should replaceGlobals inclusive version to 1.90.0: URLWhitelist -> URLListValidator", function(done) {
+			const expectedContent = fs.readFileSync(
+				rootDir + "inclusive190.expected.js",
+				"utf8"
+			);
+			const config = JSON.parse(
+				fs.readFileSync(rootDir + "inclusive.config.json", "utf8")
+			);
+			const module = new CustomFileInfo(rootDir + "inclusive190.js");
+			analyseMigrateAndTest(
+				module,
+				true,
+				expectedContent,
+				config,
+				done,
+				[
+					'trace: 26: Replace global call with "sap.base.security.URLListValidator"',
+					'trace: 26: Found call to replace "URLWhitelist.clear"',
+					'trace: 28: Replace global call with "sap.base.security.URLListValidator"',
+					'trace: 28: Found call to replace "URLWhitelist.entries"',
+					'trace: 28: Replace global call with "LEAVE"',
+					'trace: 28: Found call to replace "URLWhitelist.delete"',
+					'trace: 30: Replace global call with "sap.base.security.URLListValidator"',
+					'trace: 30: Found call to replace "URLWhitelist.add"',
+					'trace: 32: Replace global call with "sap.base.security.URLListValidator"',
+					'trace: 32: Found call to replace "URLWhitelist.entries"',
+					'trace: 33: Replace global call with "sap.base.security.URLListValidator"',
+					'trace: 33: Found call to replace "URLWhitelist.validate"',
+					'trace: 26: Replaced call "URLWhitelist.clear"',
+					'trace: 28: Replaced call "URLWhitelist.entries"',
+					"debug: 28: ignored element: URLWhitelist.delete",
+					"error: 28: Error: Ignore",
+					'trace: 30: Replaced call "URLWhitelist.add"',
+					'trace: 32: Replaced call "URLWhitelist.entries"',
+					'trace: 33: Replaced call "URLWhitelist.validate"',
+					'trace: 7: Add dependency "sap/base/security/URLListValidator" named "URLListValidator"',
+				],
+				"trace",
+				"1.90.0"
+			);
+		});
+
 		it("should replaceGlobals intervalCall", function(done) {
 			const expectedContent = fs.readFileSync(
 				rootDir + "interval.expected.js",


### PR DESCRIPTION
Updates the replacements for API which uses inclusive language.

`URLWhitelist` has been deprecated and its functionality moved to `URLListValidator` with 1.85.0
`URLWhitelist#delete` was not taken over to `URLListValidator` therefore there is
no replacement anymore (LEAVE).
Replacements prior to 1.85.0 for jQuery.sap.*WhiteList are still intact and are replaced by URLWhiteList module.

**1.58 - 1.85**
`jQuery.sap.*WhiteList -> URLWhiteList`

**1.85+**
```
jQuery.sap.*WhiteList -> URLListValidator
URLWhiteList -> URLListValidator
```