### PR TITLE
[INTERNAL] Change unused import comment from line comment to block comment

### DIFF
--- a/src/tasks/helpers/extenders/AddUnusedImportWithComment.ts
+++ b/src/tasks/helpers/extenders/AddUnusedImportWithComment.ts
@@ -22,7 +22,7 @@ class AddUnusedImportWithComment implements Extender {
 				config.newModulePath
 			) as NodeWithComments;
 			if (!node.comments) {
-				node.comments = [builders.commentLine(config.commentText)];
+				node.comments = [builders.commentBlock(config.commentText)];
 			}
 			return true;
 		}

--- a/test/addMissingDependencies/addCommentToImport.expected.js
+++ b/test/addMissingDependencies/addCommentToImport.expected.js
@@ -3,7 +3,7 @@
  */
 
 // A module
-sap.ui.define([// My Test comment
+sap.ui.define([/* My Test comment*/
 "sap/ui/dom/jquery/control"],
 	function() {
 		"use strict";

--- a/test/addMissingDependencies/jquery-plugin-addAriaLabelledBy.config.json
+++ b/test/addMissingDependencies/jquery-plugin-addAriaLabelledBy.config.json
@@ -1,0 +1,27 @@
+{
+	"modules": {
+		"jQuery Function Extensions": {
+			"*.addAriaLabelledBy": {
+				"newModulePath": "sap/ui/dom/jquery/Aria",
+				"replacer": "AddComment",
+				"commentText": " jQuery Plugin \"addAriaLabelledBy\"",
+				"finder": "JQueryFunctionExtensionFinderWithDependencyCheck",
+				"extender": "AddUnusedImportWithComment",
+				"version": "^1.58.0"
+			}
+		}
+	},
+	"finders": {
+		"JQueryFunctionExtensionFinderWithDependencyCheck": "tasks/helpers/finders/JQueryFunctionExtensionFinderWithDependencyCheck.js"
+	},
+	"extenders": {
+		"AddUnusedImportWithComment": "tasks/helpers/extenders/AddUnusedImportWithComment.js"
+	},
+	"replacers": {
+		"AddComment": "tasks/helpers/replacers/AddComment.js"
+	},
+	"comments": {
+		"unhandledReplacementComment": "TODO unhandled replacement"
+	},
+	"excludes": []
+}

--- a/test/addMissingDependencies/jquery-plugin-addAriaLabelledBy.expected.js
+++ b/test/addMissingDependencies/jquery-plugin-addAriaLabelledBy.expected.js
@@ -1,0 +1,15 @@
+sap.ui.define([
+    "./library",
+    'sap/ui/core/Core',
+    "sap/ui/core/Item",
+    'sap/ui/core/Icon',
+    'sap/ui/core/IconPool',
+    /* jQuery Plugin "addAriaLabelledBy"*/
+	"sap/ui/dom/jquery/Aria"
+],
+	function(library, Core, Item, Icon, IconPool) {
+		"use strict";
+
+		// jQuery Plugin "addAriaLabelledBy"
+		return $a.addAriaLabelledBy("");
+	});

--- a/test/addMissingDependencies/jquery-plugin-addAriaLabelledBy.js
+++ b/test/addMissingDependencies/jquery-plugin-addAriaLabelledBy.js
@@ -1,0 +1,6 @@
+sap.ui.define(["./library", 'sap/ui/core/Core', "sap/ui/core/Item", 'sap/ui/core/Icon', 'sap/ui/core/IconPool'],
+	function(library, Core, Item, Icon, IconPool) {
+		"use strict";
+
+		return $a.addAriaLabelledBy("");
+	});

--- a/test/addMissingDependencies/zIndex.expected.js
+++ b/test/addMissingDependencies/zIndex.expected.js
@@ -3,7 +3,7 @@
  */
 
 // A module
-sap.ui.define(["sap/ui/thirdparty/jquery", // jQuery Plugin "zIndex"
+sap.ui.define(["sap/ui/thirdparty/jquery", /* jQuery Plugin "zIndex"*/
 "sap/ui/dom/jquery/zIndex"],
 	function(jQuery) {
 		"use strict";

--- a/test/addMissingDependenciesTest.ts
+++ b/test/addMissingDependenciesTest.ts
@@ -289,6 +289,30 @@ describe("addMissingDependencies", () => {
 			);
 		});
 
+		it("JQuery Plugin addAriaLabelledBy", done => {
+			const expectedContent = fs.readFileSync(
+				rootDir + "jquery-plugin-addAriaLabelledBy.expected.js",
+				"utf8"
+			);
+			const config = JSON.parse(
+				fs.readFileSync(
+					rootDir + "jquery-plugin-addAriaLabelledBy.config.json",
+					"utf8"
+				)
+			);
+			const module = new CustomFileInfo(
+				rootDir + "jquery-plugin-addAriaLabelledBy.js"
+			);
+			analyseMigrateAndTest(
+				module,
+				true,
+				expectedContent,
+				config,
+				done,
+				[]
+			);
+		});
+
 		it("Identify zIndex calls", done => {
 			const expectedContent = fs.readFileSync(
 				rootDir + "zIndex.expected.js",


### PR DESCRIPTION
jquery plugin imports are added as dependency
with a comment.
This comment was a line comment which could break
the code during re-formatting. Therefore the
comment was changed to a block comment which cannot
break the code during re-formatting.

Before:
`sap.ui.define([// My Test comment`

Now:
`sap.ui.define([/* My Test comment*/`

Fixes: #29