### PR TITLE
[FEATURE] Re-use variable name for addMissingDependencies task

### DIFF
--- a/src/tasks/addMissingDependencies.ts
+++ b/src/tasks/addMissingDependencies.ts
@@ -418,9 +418,17 @@ async function migrate(args: Mod.MigrateArguments): Promise<boolean> {
 
 		// Try to replace the call
 		try {
+			// retrieve variable name from existing import and use it as name argument of replace call
+			let variableNameToUse = oReplace.config.newVariableName;
+			if (oReplace.config.newModulePath) {
+				variableNameToUse =
+					analyseResult.defineCall.getParamNameByImport(
+						oReplace.config.newModulePath
+					) || variableNameToUse;
+			}
 			mReplacerFuncs[oReplace.importObj.replacerName].replace(
 				oNodePath,
-				oReplace.config.newVariableName,
+				variableNameToUse,
 				oReplace.config.functionName,
 				oReplace.module,
 				oReplace.config

--- a/src/util/SapUiDefineCall.ts
+++ b/src/util/SapUiDefineCall.ts
@@ -404,7 +404,13 @@ export class SapUiDefineCall {
 						"Dependency is not a literal in " + this.name
 					);
 				}
-				return oElement.value === sModule;
+				return (
+					oElement.value === sModule ||
+					SapUiDefineCall._resolveRelativeImports(
+						oElement.value,
+						this.name
+					) === sModule
+				);
 			}
 		);
 		if (aAlreadyMatchingElements.length === 0) {

--- a/test/addMissingDependencies/variableReuse.config.json
+++ b/test/addMissingDependencies/variableReuse.config.json
@@ -1,0 +1,28 @@
+{
+	"modules": {
+		"test findings": {
+			"test": {
+				"newModulePath": "x/y/z",
+				"newVariableName": "mymod",
+				"replacer": "ModuleFunction",
+				"finder": "CallWithArgumentFinder",
+				"finderIncludesName": "superparam",
+				"extender": "AddImport",
+				"version": "^1.58.0"
+			}
+		}
+	},
+	"finders": {
+		"CallWithArgumentFinder": "tasks/helpers/finders/CallWithArgumentFinder.js"
+	},
+	"extenders": {
+		"AddImport": "tasks/helpers/extenders/AddImport.js"
+	},
+	"replacers": {
+		"ModuleFunction": "tasks/helpers/replacers/ModuleFunction.js"
+	},
+	"comments": {
+		"unhandledReplacementComment": "TODO unhandled replacement"
+	},
+	"excludes": []
+}

--- a/test/addMissingDependencies/variableReuse.expected.js
+++ b/test/addMissingDependencies/variableReuse.expected.js
@@ -1,0 +1,31 @@
+/*!
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["m/mymod","x/y/z"],
+	function(myModule, mysupermodulefunction) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		A.b = mysupermodulefunction();
+
+		A.v = myModule.x();
+
+		/**
+		 *
+		 * @param oParam
+		 * @param oEvent
+		 */
+		A.x = function (oParam, oEvent) {
+			var x = mysupermodulefunction("superparam");
+			x();
+		};
+
+		return A;
+	}, /* bExport= */ true);

--- a/test/addMissingDependencies/variableReuse.js
+++ b/test/addMissingDependencies/variableReuse.js
@@ -1,0 +1,31 @@
+/*!
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["m/mymod","x/y/z"],
+	function(myModule, mysupermodulefunction) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		A.b = mysupermodulefunction();
+
+		A.v = myModule.x();
+
+		/**
+		 *
+		 * @param oParam
+		 * @param oEvent
+		 */
+		A.x = function (oParam, oEvent) {
+			var x = myModule.doit("superparam");
+			x();
+		};
+
+		return A;
+	}, /* bExport= */ true);

--- a/test/addMissingDependenciesTest.ts
+++ b/test/addMissingDependenciesTest.ts
@@ -453,5 +453,24 @@ describe("addMissingDependencies", () => {
 				[]
 			);
 		});
+
+		it("variableReuse", done => {
+			const expectedContent = fs.readFileSync(
+				rootDir + "variableReuse.expected.js",
+				"utf8"
+			);
+			const config = JSON.parse(
+				fs.readFileSync(rootDir + "variableReuse.config.json", "utf8")
+			);
+			const module = new CustomFileInfo(rootDir + "variableReuse.js");
+			analyseMigrateAndTest(
+				module,
+				true,
+				expectedContent,
+				config,
+				done,
+				[]
+			);
+		});
 	});
 });


### PR DESCRIPTION
if a module path is provided and the variable name is different
from the one configured, the existing variable name will be used
for the replacer call.

If dependencies are specified in a relative manner, e.g. `"./a"`
these are supported as well.