### PR TITLE
Replace sap.ui.getCore().getConfiguration() with Configuration Module

### DIFF
--- a/defaultConfig/addMissingDependencies.config.json
+++ b/defaultConfig/addMissingDependencies.config.json
@@ -191,16 +191,6 @@
 				"version": "^1.58.0"
 			}
 		},
-		"Singletons": {
-			"sap.ui.getCore().getConfiguration()@1.106": {
-				"newModulePath": "sap/ui/core/Configuration",
-				"newVariableName": "Configuration",
-				"replacer": "Module",
-				"finder": "GlobalCoreConfigurationFinder",
-				"extender": "AddImport",
-				"version": "^1.106.0"
-			}
-		},
 		"Replacement interim solution fix": {
 			"UriParameters with url param (fromQuery search)": {
 				"newExpressionArgsLength": 1,

--- a/defaultConfig/addMissingDependencies.config.json
+++ b/defaultConfig/addMissingDependencies.config.json
@@ -191,6 +191,16 @@
 				"version": "^1.58.0"
 			}
 		},
+		"Singletons": {
+			"sap.ui.getCore().getConfiguration()@1.106": {
+				"newModulePath": "sap/ui/core/Configuration",
+				"newVariableName": "Configuration",
+				"replacer": "Module",
+				"finder": "GlobalCoreConfigurationFinder",
+				"extender": "AddImport",
+				"version": "^1.106.0"
+			}
+		},
 		"Replacement interim solution fix": {
 			"UriParameters with url param (fromQuery search)": {
 				"newExpressionArgsLength": 1,
@@ -244,6 +254,7 @@
 		}
 	},
 	"finders": {
+		"GlobalCoreConfigurationFinder": "tasks/helpers/finders/GlobalCoreConfigurationFinder.js",
 		"FunctionExtensionFinder": "tasks/helpers/finders/FunctionExtensionFinder.js",
 		"FunctionExtensionFinderWithDependencyCheck": "tasks/helpers/finders/FunctionExtensionFinderWithDependencyCheck.js",
 		"JQueryControlCallFinder": "tasks/helpers/finders/JQueryControlCallFinder.js",

--- a/src/tasks/helpers/finders/GlobalCoreConfigurationFinder.ts
+++ b/src/tasks/helpers/finders/GlobalCoreConfigurationFinder.ts
@@ -1,0 +1,57 @@
+import {Syntax} from "esprima";
+import * as ESTree from "estree";
+
+import {EMPTY_FINDER_RESULT, Finder, FinderResult} from "../../../dependencies";
+import {SapUiDefineCall} from "../../../util/SapUiDefineCall";
+
+const getPropertyValue = (node: ESTree.Node) => {
+	if (node.type === Syntax.Identifier) {
+		return node.name;
+	}
+	return "";
+};
+
+class FunctionExtensionFinder implements Finder {
+	/**
+	 * Finds expression that matches one of the following conditions
+	 * <ul>
+	 * <li>sap.ui.getCore().getConfiguration()</li>
+	 * </ul>
+	 */
+	find(
+		node: ESTree.Node,
+		config: {},
+		sConfigName: string,
+		defineCall: SapUiDefineCall
+	): FinderResult {
+		const oInterestingNode = node;
+		const bGetCoreGetConfigurationCall =
+			oInterestingNode.type === Syntax.CallExpression &&
+			oInterestingNode.callee.type === Syntax.MemberExpression &&
+			oInterestingNode.arguments.length === 0 &&
+			getPropertyValue(oInterestingNode.callee.property) ===
+				"getConfiguration" &&
+			oInterestingNode.callee.object.type === Syntax.CallExpression &&
+			oInterestingNode.callee.object.arguments.length === 0 &&
+			oInterestingNode.callee.object.callee.type ===
+				Syntax.MemberExpression &&
+			getPropertyValue(oInterestingNode.callee.object.callee.property) ===
+				"getCore" &&
+			oInterestingNode.callee.object.callee.object.type ===
+				Syntax.MemberExpression &&
+			getPropertyValue(
+				oInterestingNode.callee.object.callee.object.property
+			) === "ui" &&
+			getPropertyValue(
+				oInterestingNode.callee.object.callee.object.object
+			) === "sap";
+
+		if (bGetCoreGetConfigurationCall) {
+			return {configName: sConfigName};
+		} else {
+			return EMPTY_FINDER_RESULT;
+		}
+	}
+}
+
+module.exports = new FunctionExtensionFinder();

--- a/test/addMissingDependencies/coreConfiguration/configuration.config.json
+++ b/test/addMissingDependencies/coreConfiguration/configuration.config.json
@@ -1,0 +1,26 @@
+{
+	"modules": {
+		"GLOBALS": {
+			"sap.ui.getCore().getConfiguration()": {
+				"newModulePath": "sap/ui/core/Configuration",
+				"newVariableName": "Configuration",
+				"replacer": "Module",
+				"finder": "GlobalCoreConfigurationFinder",
+				"extender": "AddImport"
+			}
+		}
+	},
+	"finders": {
+		"GlobalCoreConfigurationFinder": "tasks/helpers/finders/GlobalCoreConfigurationFinder.js"
+	},
+	"extenders": {
+		"AddImport": "tasks/helpers/extenders/AddImport.js"
+	},
+	"replacers": {
+		"Module": "tasks/helpers/replacers/Module.js"
+	},
+	"comments": {
+		"unhandledReplacementComment": "TODO unhandled replacement"
+	},
+	"excludes": []
+}

--- a/test/addMissingDependencies/coreConfiguration/configuration.expected.js
+++ b/test/addMissingDependencies/coreConfiguration/configuration.expected.js
@@ -29,6 +29,11 @@ sap.ui.define(["sap/ui/core/Configuration"],
 
 				x$.doit(sKey);
 
+				// should not be replaced because there must be no call arguments
+				sap.ui.getCore().getConfiguration("test");
+
+				sap.ui.getCore("test").getConfiguration();
+
 				alert(Configuration.getFormatSettings().getFormatLocale())
 
 				return Configuration.getFormatSettings().getLocale();

--- a/test/addMissingDependencies/coreConfiguration/configuration.expected.js
+++ b/test/addMissingDependencies/coreConfiguration/configuration.expected.js
@@ -1,0 +1,39 @@
+/*!
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define(["sap/ui/core/Configuration"],
+	function(Configuration) {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param iIndex
+		 */
+		A.x = function (oParam, iIndex) {
+
+			if (oParam.control(0)) {
+				var sKey = "Test." + iconName + oParam.control;
+				if (Configuration && Configuration.getTimezone()) {
+					Configuration.setTimezone("America/New_York")
+				}
+				var x$ = Configuration;
+
+				x$.doit(sKey);
+
+				alert(Configuration.getFormatSettings().getFormatLocale())
+
+				return Configuration.getFormatSettings().getLocale();
+			}
+		};
+
+		return A;
+	}, /* bExport= */ true);

--- a/test/addMissingDependencies/coreConfiguration/configuration.js
+++ b/test/addMissingDependencies/coreConfiguration/configuration.js
@@ -29,6 +29,11 @@ sap.ui.define([],
 
 				x$.doit(sKey);
 
+				// should not be replaced because there must be no call arguments
+				sap.ui.getCore().getConfiguration("test");
+
+				sap.ui.getCore("test").getConfiguration();
+
 				alert(sap.ui.getCore().getConfiguration().getFormatSettings().getFormatLocale())
 
 				return sap.ui.getCore().getConfiguration().getFormatSettings().getLocale();

--- a/test/addMissingDependencies/coreConfiguration/configuration.js
+++ b/test/addMissingDependencies/coreConfiguration/configuration.js
@@ -1,0 +1,39 @@
+/*!
+ * ${copyright}
+ */
+
+// A module
+sap.ui.define([],
+	function() {
+		"use strict";
+
+		/**
+		 *
+		 * @type {{}}
+		 */
+		var A = {};
+
+		/**
+		 *
+		 * @param oParam
+		 * @param iIndex
+		 */
+		A.x = function (oParam, iIndex) {
+
+			if (oParam.control(0)) {
+				var sKey = "Test." + iconName + oParam.control;
+				if (sap.ui.getCore().getConfiguration() && sap.ui.getCore().getConfiguration().getTimezone()) {
+					sap.ui.getCore().getConfiguration().setTimezone("America/New_York")
+				}
+				var x$ = sap.ui.getCore().getConfiguration();
+
+				x$.doit(sKey);
+
+				alert(sap.ui.getCore().getConfiguration().getFormatSettings().getFormatLocale())
+
+				return sap.ui.getCore().getConfiguration().getFormatSettings().getLocale();
+			}
+		};
+
+		return A;
+	}, /* bExport= */ true);

--- a/test/addMissingDependenciesTest.ts
+++ b/test/addMissingDependenciesTest.ts
@@ -516,5 +516,25 @@ describe("addMissingDependencies", () => {
 				[]
 			);
 		});
+
+		it("should replace sap.ui.getCore().getConfiguration() with Configuration module", done => {
+			const subDir = rootDir + "coreConfiguration/";
+			const expectedContent = fs.readFileSync(
+				subDir + "configuration.expected.js",
+				"utf8"
+			);
+			const config = JSON.parse(
+				fs.readFileSync(subDir + "configuration.config.json", "utf8")
+			);
+			const module = new CustomFileInfo(subDir + "configuration.js");
+			analyseMigrateAndTest(
+				module,
+				true,
+				expectedContent,
+				config,
+				done,
+				[]
+			);
+		});
 	});
 });


### PR DESCRIPTION
Since UI5 1.106 alls calls to `sap.ui.getCore().getConfiguration()`
should be replaced by Sngleton module `Configuration`

Can be manually enabled by adding the following statement to the `modules` section of `addMissingDependencies.json`

```json
		"Singletons": {
			"sap.ui.getCore().getConfiguration()@1.106": {
				"newModulePath": "sap/ui/core/Configuration",
				"newVariableName": "Configuration",
				"replacer": "Module",
				"finder": "GlobalCoreConfigurationFinder",
				"extender": "AddImport",
				"version": "^1.106.0"
			}
		},
```